### PR TITLE
Add Show Example text for MI hidden code blocks

### DIFF
--- a/en/micro-integrator/docs/assets/css/theme.css
+++ b/en/micro-integrator/docs/assets/css/theme.css
@@ -288,6 +288,11 @@ html .md-typeset .superfences-tabs > label:hover {
     font-weight: 500;
 }
 
+.mb-config-catalog .superfences-tabs > label:after {
+    content: "Show Example";
+    font-weight: 500;
+}
+
 .mb-config-catalog .superfences-tabs .doc-wrapper {
     padding: .525rem;
 }


### PR DESCRIPTION
## Purpose
Adds Show Example text for MI hidden code blocks in the reference section

Before
![Screen Shot 2019-10-03 at 11 24 28 AM](https://user-images.githubusercontent.com/18122888/66102813-47f9f580-e5d1-11e9-9673-83c450e64b9d.png)

After
![Screen Shot 2019-10-03 at 11 25 11 AM](https://user-images.githubusercontent.com/18122888/66102826-4f210380-e5d1-11e9-8078-676a7bf00e1b.png)

