### PR TITLE
Change cli remote login instructions for windows

### DIFF
--- a/en/micro-integrator/docs/administer-and-observe/using-the-command-line-interface.md
+++ b/en/micro-integrator/docs/administer-and-observe/using-the-command-line-interface.md
@@ -98,8 +98,13 @@ mi remote login
 
 If you want to login using one line command, use the following command:
 
+!!! Note 
+
+If you are a Windows user, you needs to login as above command.
+
 ```bash
 mi remote login [username] [password]
+
 ```
 
 To logout from the CLI, please use the following command: 


### PR DESCRIPTION
## Purpose
cli remote login command not working in windows if the user tries to log by adding username and then enter the password. It does not allow user to add the password. As a workaround in windows, the user can add the user name and the password together with the command as shown below,

mi remote login username password

## Related Issues
https://github.com/wso2/micro-integrator/issues/1034
