### PR TITLE
Change cli remote login instructions for windows

### DIFF
--- a/en/micro-integrator/docs/administer-and-observe/using-the-command-line-interface.md
+++ b/en/micro-integrator/docs/administer-and-observe/using-the-command-line-interface.md
@@ -85,6 +85,10 @@ mi remote login
 
 If you want to login using one line command, use the following command:
 
+!!! Note 
+
+If you are a Windows user, you needs to login as below command.
+
 ```bash
 mi remote login [username] [password]
 ```

--- a/en/micro-integrator/docs/administer-and-observe/using-the-command-line-interface.md
+++ b/en/micro-integrator/docs/administer-and-observe/using-the-command-line-interface.md
@@ -83,11 +83,10 @@ To login using the CLI, use the following command. This will ask for the usernam
 mi remote login
 ```
 
-If you want to login using one line command, use the following command:
+If you want to login using a one line command, use the following command:
 
 !!! Note 
-
-If you are a Windows user, you needs to login as below command.
+    If you are on **Windows**, you must always login with the following command.
 
 ```bash
 mi remote login [username] [password]


### PR DESCRIPTION
## Purpose
cli remote login command not working in windows if the user tries to log by adding username and then enter the password. It does not allow user to add the password. As a workaround in windows, the user can add the user name and the password together with the command as shown below,

mi remote login username password

## Related Issues
wso2/micro-integrator#1034
