### PR TITLE
Update tutorial workspace setup documentation

### DIFF
--- a/en/micro-integrator/docs/use-cases/tutorials/exposing-several-services-as-a-single-service.md
+++ b/en/micro-integrator/docs/use-cases/tutorials/exposing-several-services-as-a-single-service.md
@@ -14,7 +14,7 @@ To build this mediation flow, you will update the API resource from the [previou
 
 To set up the tools:
 
--   Select the relevant [WSO2 Integration Studio](https://wso2.com/integration/tooling/) based on your operating system and extract the ZIP file. The path to this folder is referred to as `MI_TOOLING_HOME` throughout this tutorial.
+-   Download the relevant [WSO2 Integration Studio](https://wso2.com/integration/tooling/) based on your operating system. The path to the extracted/installed folder is referred to as `MI_TOOLING_HOME` throughout this tutorial.
 -  Download the [CLI Tool](https://wso2.com/integration/micro-integrator/install/) for monitoring artifact deployments.
 
 If you did not try the [Transforming Message Content](transforming-message-content.md) tutorial yet, open WSO2 Integration Studio, click **File** , and then click **Import**. Next, select **Existing WSO2 Projects into workspace** under the **WSO2** category, click **Next** and upload the [pre-packaged project](https://github.com/wso2-docs/WSO2_EI/blob/master/Integration-Tutorial-Artifacts/TransformingContentTutorial.zip). 

--- a/en/micro-integrator/docs/use-cases/tutorials/file-processing.md
+++ b/en/micro-integrator/docs/use-cases/tutorials/file-processing.md
@@ -10,7 +10,7 @@ The result of the query should be as follows when you query to view the records
 
 ### Step 1: Set up the workspace
 
--  Select the relevant [WSO2 Integration Studio](https://wso2.com/integration/tooling/) based on your operating system and extract the ZIP file.  The path to the extracted folder is referred to as `MI_TOOLING_HOME` throughout this tutorial.
+-  Download the relevant [WSO2 Integration Studio](https://wso2.com/integration/tooling/) based on your operating system.  The path to the extracted/installed folder is referred to as `MI_TOOLING_HOME` throughout this tutorial.
 -  Download the [CLI Tool](https://wso2.com/integration/micro-integrator/install/) for monitoring artifact deployments.
 
 Let's setup a MySQL database:

--- a/en/micro-integrator/docs/use-cases/tutorials/routing-requests-based-on-message-content.md
+++ b/en/micro-integrator/docs/use-cases/tutorials/routing-requests-based-on-message-content.md
@@ -15,8 +15,8 @@ To implement this use case, you will add a new REST resource to the existing RES
 
 To set up the tools:
 
--   Select the relevant [WSO2 Integration Studio](https://wso2.com/integration/tooling/) based on your operating system and extract the ZIP file.  The path to this folder is referred to as `MI_TOOLING_HOME` throughout this tutorial.
--   Download the [CLI Tool](https://wso2.com/integration/micro-integrator/install/) for monitoring artifact deployments.
+-  Download the relevant [WSO2 Integration Studio](https://wso2.com/integration/tooling/) based on your operating system.  The path to the extracted/installed folder is referred to as `MI_TOOLING_HOME` throughout this tutorial.
+-  Download the [CLI Tool](https://wso2.com/integration/micro-integrator/install/) for monitoring artifact deployments.
 
 If you did not try the [Sending a Simple Message to a Service](sending-a-simple-message-to-a-service.md) tutorial yet, open WSO2 Integration Studio, click **File**, and click **Import**. Next, expand the **WSO2** category and select **Existing WSO2 Projects into workspace**, click **Next** and upload the [pre-packaged
 project](https://github.com/wso2-docs/WSO2_EI/blob/master/Integration-Tutorial-Artifacts/SimpleMessageToServiceTutorial.zip). 

--- a/en/micro-integrator/docs/use-cases/tutorials/sending-a-simple-message-to-a-datasource.md
+++ b/en/micro-integrator/docs/use-cases/tutorials/sending-a-simple-message-to-a-datasource.md
@@ -11,7 +11,7 @@ Google spreadsheets, and more. The following sections describe how you can use W
 
 To set up the tools:
 
--  Select the relevant [WSO2 Integration Studio](https://wso2.com/integration/tooling/) based on your operating system and extract the ZIP file.  The path to the extracted folder is referred to as `MI_TOOLING_HOME` throughout this tutorial.
+-  Download the relevant [WSO2 Integration Studio](https://wso2.com/integration/tooling/) based on your operating system.  The path to the extracted/installed folder is referred to as `MI_TOOLING_HOME` throughout this tutorial.
 -  Download the [CLI Tool](https://wso2.com/integration/micro-integrator/install/) for monitoring artifact deployments.
 
 To demonstrate how data services work, we will use a MySQL database as the datasource. Follow the steps given below to set up a MySQL database:

--- a/en/micro-integrator/docs/use-cases/tutorials/sending-a-simple-message-to-a-service.md
+++ b/en/micro-integrator/docs/use-cases/tutorials/sending-a-simple-message-to-a-service.md
@@ -10,7 +10,7 @@ To implement this use case, you will create a REST API resource and other artifa
 
 ### Step 1: Set up the workspace
 
--  Select the relevant [WSO2 Integration Studio](https://wso2.com/integration/tooling/) based on your operating system and extract the ZIP file.  The path to the extracted folder is referred to as `MI_TOOLING_HOME` throughout this tutorial.
+-  Download the relevant [WSO2 Integration Studio](https://wso2.com/integration/tooling/) based on your operating system.  The path to the extracted/installed folder is referred to as `MI_TOOLING_HOME` throughout this tutorial.
 -  Download the [CLI Tool](https://wso2.com/integration/micro-integrator/install/) for monitoring artifact deployments.
 
 ### Step 2: Develop the integration artifacts

--- a/en/micro-integrator/docs/use-cases/tutorials/storing-and-forwarding-messages.md
+++ b/en/micro-integrator/docs/use-cases/tutorials/storing-and-forwarding-messages.md
@@ -13,8 +13,7 @@ Processor** to retrieve the message from the store before delivering it to the b
 
 To set up the tools:
 
--   Select the relevant [WSO2 Integration Studio](https://wso2.com/integration/tooling/) based on your operating system and extract the
-    ZIP file.  The path to this folder is referred to as `MI_TOOLING_HOME` throughout this tutorial.
+-   Download the relevant [WSO2 Integration Studio](https://wso2.com/integration/tooling/) based on your operating system. The path to the extracted/installed folder is referred to as `MI_TOOLING_HOME` throughout this tutorial.
 -  Download the [CLI Tool](https://wso2.com/integration/micro-integrator/install/) for monitoring artifact deployments.
 
 If you did not try the [Exposing Several Services as a Single Service](exposing-several-services-as-a-single-service.md) tutorial yet, open WSO2 Integration Studio, click **File** , and then click **Import** . Next, select **Existing WSO2 Projects into workspace** under the **WSO2** category, click **Next** and upload the [pre-packaged project](https://github.com/wso2-docs/WSO2_EI/blob/master/Integration-Tutorial-Artifacts/ExposingSeveralServicesTutorial.zip).

--- a/en/micro-integrator/docs/use-cases/tutorials/transforming-message-content.md
+++ b/en/micro-integrator/docs/use-cases/tutorials/transforming-message-content.md
@@ -50,7 +50,7 @@ The client message format must be transformed to the back-end service message fo
 
 To set up the tools:
 
--  Select the relevant [WSO2 Integration Studio](https://wso2.com/integration/tooling/) based on your operating system and extract the ZIP file.  The path to this folder is referred to as `MI_TOOLING_HOME` throughout this tutorial.
+-  Download the relevant [WSO2 Integration Studio](https://wso2.com/integration/tooling/) based on your operating system. The path to the extracted/installed folder is referred to as `MI_TOOLING_HOME` throughout this tutorial.
 -  Download the [CLI Tool](https://wso2.com/integration/micro-integrator/install/) for monitoring artifact deployments.
 
 If you did not try the [Routing Requests Based on Message Content](routing-requests-based-on-message-content.md) tutorial yet, open WSO2 Integration Studio, click **File**, and then click **Import**. Next, select **Existing WSO2 Projects into workspace** under the **WSO2** category, click **Next** and upload the [pre-packaged project](https://github.com/wso2-docs/WSO2_EI/blob/master/Integration-Tutorial-Artifacts/RequestRoutingTutorial.zip).

--- a/en/micro-integrator/docs/use-cases/tutorials/using-inbound-endpoints.md
+++ b/en/micro-integrator/docs/use-cases/tutorials/using-inbound-endpoints.md
@@ -11,8 +11,7 @@ In this sample scenario, you will use an **Inbound Endpoint** to expose an alrea
 To set up the tools:
 
 -   Go to the [product page](https://wso2.com/integration/) of **WSO2 Micro Integrator**, download the product installer and run it to set up the product.
--   Select the relevant [WSO2 Integration Studio](https://wso2.com/integration/tooling/) based on your operating system and extract the
-    ZIP file.  The path to this folder is referred to as `MI_TOOLING_HOME` throughout this tutorial.
+-   Download the relevant [WSO2 Integration Studio](https://wso2.com/integration/tooling/) based on your operating system. The path to the extracted/installed folder is referred to as `MI_TOOLING_HOME` throughout this tutorial.
 -   Download the CLI Tool for monitoring artifact deployments.
 
 To set up the previous artifacts:

--- a/en/micro-integrator/docs/use-cases/tutorials/using-scheduled-tasks.md
+++ b/en/micro-integrator/docs/use-cases/tutorials/using-scheduled-tasks.md
@@ -8,7 +8,7 @@ The sections below demonstrate an example of scheduling a task (using the defaul
 
 ### Step 1: Set up the workspace
 
--  Select the relevant [WSO2 Integration Studio](https://wso2.com/integration/tooling/) based on your operating system and extract the ZIP file.  The path to the extracted folder is referred to as `MI_TOOLING_HOME` throughout this tutorial.
+-  Download the relevant [WSO2 Integration Studio](https://wso2.com/integration/tooling/) based on your operating system. The path to the extracted/installed folder is referred to as `MI_TOOLING_HOME` throughout this tutorial.
 -  Download the [CLI Tool](https://wso2.com/integration/micro-integrator/install/) for monitoring artifact deployments.
 
 ### Step 2: Develop the integration artifacts

--- a/en/micro-integrator/docs/use-cases/tutorials/using-templates.md
+++ b/en/micro-integrator/docs/use-cases/tutorials/using-templates.md
@@ -14,8 +14,7 @@ on how to work with templates using WSO2 Integration Studio.
 To set up the tools:
 
 -   Go to the [product page](https://wso2.com/integration/) of **WSO2 Micro Integrator**, download the product installer and run it to set up the product.
--   Select the relevant [WSO2 Integration Studio](https://wso2.com/integration/tooling/) based on your operating system and extract the
-    ZIP file.  The path to this folder is referred to as `MI_TOOLING_HOME` throughout this tutorial.
+-   Download the relevant [WSO2 Integration Studio](https://wso2.com/integration/tooling/) based on your operating system. The path to the extracted/installed folder is referred to as `MI_TOOLING_HOME` throughout this tutorial.
 -   Download the CLI Tool for monitoring artifact deployments.
 
 To set up the previous artifacts:

--- a/en/micro-integrator/docs/use-cases/tutorials/using-the-gmail-connector.md
+++ b/en/micro-integrator/docs/use-cases/tutorials/using-the-gmail-connector.md
@@ -12,8 +12,7 @@ When you integrate the systems in your organizaion, it is also necessary to inte
 
 To set up the tools:
 
--   Select the relevant [WSO2 Integration Studio](https://wso2.com/integration/tooling/) based on your operating system and extract the
-    ZIP file.  The path to this folder is referred to as `MI_TOOLING_HOME` throughout this tutorial.
+-   Download the relevant [WSO2 Integration Studio](https://wso2.com/integration/tooling/) based on your operating system.  The path to the extracted/installed folder is referred to as `MI_TOOLING_HOME` throughout this tutorial.
 -   Download the [CLI Tool](https://wso2.com/integration/micro-integrator/install/) for monitoring artifact deployments.
 
 If you did not try the [asynchronous messaging](storing-and-forwarding-messages.md) tutorial yet, open WSO2 Integration Studio, click **File** , and then click **Import** . Next, select **Existing WSO2 Projects into workspace** under the **WSO2** category, click **Next** and upload the [pre-packaged project](https://github.com/wso2-docs/WSO2_EI/blob/master/Integration-Tutorial-Artifacts/StoreAndForwardTutorial.zip).


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.
Tutorial workspace mentions that the Integration Studio should be extracted which is not the case for MacOS.

