### PR TITLE
Fix startup script filename in SI

### DIFF
--- a/en/streaming-integrator/docs/setup/installing-si-in-vm.md
+++ b/en/streaming-integrator/docs/setup/installing-si-in-vm.md
@@ -138,13 +138,13 @@ This script automatically assigns the JAVA_HOME of your VM to the root user of y
 
     * On **MacOS/Linux/CentOS**
       ```bash
-      sh streaming-integrator.sh
+      sh server.sh
       ```
 
 
     * On **Windows**
       ```bash
-      streaming-integrator.bat
+      server.bat
       ```
 
 By default, the HTTP listener port is 8290 and the default HTTPS


### PR DESCRIPTION
## Purpose
This PR fixes a startup script filename in the Streaming Integrator.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes