### PR TITLE
Fix header redirection issue

### DIFF
--- a/en/home-page/mkdocs.yml
+++ b/en/home-page/mkdocs.yml
@@ -23,7 +23,7 @@ site_url: https://ei.docs.wso2.com/en/latest/
 # Repository
 repo_name: wso2/docs-ei
 repo_url: https://github.com/wso2/docs-ei
-edit_uri: https://github.com/wso2/docs-ei/edit/master/en/micro-integrator/docs/
+edit_uri: https://github.com/wso2/docs-ei/edit/master/en/home-page/docs/
 
 # Copyright
 copyright: WSO2 Enterprise Integrator - Documentation

--- a/en/micro-integrator/mkdocs.yml
+++ b/en/micro-integrator/mkdocs.yml
@@ -18,7 +18,7 @@
 site_name: WSO2 Enterprise Integrator Documentation
 site_description: Documentation for WSO2 Enterprise Integrator
 site_author: WSO2
-site_url: https://ei.docs.wso2.com/en/latest/micro-integrator/
+site_url: https://ei.docs.wso2.com/en/latest/
 
 # Repository
 repo_name: wso2/docs-ei
@@ -153,7 +153,7 @@ nav:
             - 'Kafka Inbound Endpoint': 'use-cases/examples/inbound_endpoint_examples/inbound-endpoint-kafka.md'
             - 'Secured WebSocket Inbound Endpoint': 'use-cases/examples/inbound_endpoint_examples/inbound-endpoint-secured-websocket.md'
             - 'Using Inbound Endpoints with Registry': 'use-cases/examples/inbound_endpoint_examples/inbound-endpoint-with-registry.md'
-          - Scheduled Tasks: 
+          - Scheduled Tasks:
             - 'Task Scheduling using a Simple Trigger': 'use-cases/examples/scheduled-tasks/task-scheduling-simple-trigger.md'
             - 'Injecting Messages to a RESTful Endpoint': 'use-cases/examples/scheduled-tasks/injecting-messages-to-rest-endpoint.md'
           - 'Local Registry Entries': 'use-cases/examples/registry_examples/local-registry-entries.md'
@@ -349,7 +349,7 @@ nav:
     - References:
       - 'Product Configurations': 'references/config-catalog.md'
       - Synapse Configurations:
-        - Mediator Catalog: 
+        - Mediator Catalog:
           - 'About Mediators': 'references/mediators/about-mediators.md'
           - 'Aggregate Mediators' : 'references/mediators/aggregate-Mediator.md'
           - 'Builder Mediator' : 'references/mediators/builder-Mediator.md'

--- a/en/streaming-integrator/mkdocs.yml
+++ b/en/streaming-integrator/mkdocs.yml
@@ -18,7 +18,7 @@
 site_name: WSO2 Enterprise Integrator Documentation
 site_description: Documentation for WSO2 Enterprise Integrator
 site_author: WSO2
-site_url: https://ei.docs.wso2.com/en/latest/streaming-integrator/
+site_url: https://ei.docs.wso2.com/en/latest/
 
 # Repository
 repo_name: wso2/docs-ei


### PR DESCRIPTION
## Purpose
When clicking on the "WSO2" logo icon in the header, the site navigates to the `index.md` of the relevant section, not the root level landing page. This PR fixes that issue by redirecting the site to the root level landing page.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes