### PR TITLE
Add docs for hot deployment

### DIFF
--- a/en/micro-integrator/docs/develop/hot-deployment.md
+++ b/en/micro-integrator/docs/develop/hot-deployment.md
@@ -1,19 +1,20 @@
 # Hot Deploying Artifacts
 
-Hot deploying in micro integrator allows you to dynamically deploy synapse artifacts(.xml), dataservices(.dbs), carbon applications(.car), etc without restarting the server.
+Hot deployment is the process of dynamically deploying your synapse artifacts (XML), dataservices(DBS), carbon applications (CAR), etc., in your Micro Integrator. That is, it is not required to restart the server for the artifact deployment to be effective.
 
-This feature would be helpful mostly during the testing phase in the development environment when the MI is configured to run in a VM environment, as it reduces the overhead of restarting the server for each new synapse artifacts, dss artifacts, or CApp deployment.
+Hot deployment is useful for testing your integration artifacts **in a VM environment**. Because you don't have to restart the server every time you deploy an artifact, the testing time will be shorter and efficient.
 
-**Note:** However as a best practice in Micro Integrator, we are not encouraging to enable both readiness probe and the hot deployment at the same time because it might affect the correctness of the results that the readiness probe will be giving. Readiness probe will give results based on the deployment that takes place only during the server startup time, but when the hot deployment is enabled, there is a chance that the previously failed carbon apps (faulty carbon apps) being valid because of the dynamic deployment behavior. 
+!!! Warning
+    Do not enable hot deployment when the Readiness Probe is enabled for the server. The Readiness Probe verifies the readiness of the server during server startup. That is, if there are faulty artifacts deployed in the server, the Readiness Probe should be allowed to identify them during server startup. However, if hot deployment is enabled, faulty artifacts can be deployed in the server during the server runtime, which prevents the readiness probe from functioning accurately.  
 
-Therefore, make sure you disable hot deployment in the server if you want the readiness probe to be worked perfectly as expected.
+Be sure to disable hot deployment in the server if you want the readiness probe to work as expected.
 
-##Enabling Hot Deployment
-You can enable hot deployment in Micro Integrator by configuring the following deployment parameter in the deployment.toml file.
+## Enabling hot deployment
+Open the `deployment.toml` file from the `<MI_HOME>/conf` directory and add the following configuration parameter to enable hot deployment.
 
 ```toml
 [server]
 hot_deployment = true
 ```
 
-Please visit [product configuration catalog](../../references/synapse-properties/config-catalog) to see more on the **hot deployment** parameter in Micro Integrator.
+See the [complete list of server configurations](../../references/synapse-properties/config-catalog).

--- a/en/micro-integrator/docs/develop/hot-deployment.md
+++ b/en/micro-integrator/docs/develop/hot-deployment.md
@@ -1,0 +1,19 @@
+# Hot Deploying Artifacts
+
+Hot deploying in micro integrator allows you to dynamically deploy synapse artifacts(.xml), dataservices(.dbs), carbon applications(.car), etc without restarting the server.
+
+This feature would be helpful mostly during the testing phase in the development environment when the MI is configured to run in a VM environment, as it reduces the overhead of restarting the server for each new synapse artifacts, dss artifacts, or CApp deployment.
+
+**Note:** However as a best practice in Micro Integrator, we are not encouraging to enable both readiness probe and the hot deployment at the same time because it might affect the correctness of the results that the readiness probe will be giving. Readiness probe will give results based on the deployment that takes place only during the server startup time, but when the hot deployment is enabled, there is a chance that the previously failed carbon apps (faulty carbon apps) being valid because of the dynamic deployment behavior. 
+
+Therefore, make sure you disable hot deployment in the server if you want the readiness probe to be worked perfectly as expected.
+
+##Enabling Hot Deployment
+You can enable hot deployment in Micro Integrator by configuring the following deployment parameter in the deployment.toml file.
+
+```toml
+[server]
+hot_deployment = true
+```
+
+Please visit [product configuration catalog](../../references/synapse-properties/config-catalog) to see more on the **hot deployment** parameter in Micro Integrator.

--- a/en/micro-integrator/docs/references/config-catalog.md
+++ b/en/micro-integrator/docs/references/config-catalog.md
@@ -207,6 +207,26 @@ proxy_context_path = ""
                                         <p></p>
                                     </div>
                                 </div>
+                            </div><div class="param-name">
+                                  <span class="param-name-wrap"> <code>hot_deployment</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>false</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>&quot;true&quot; or &quot;false&quot;</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Use this paramater to enable hot deployment for the server. When hot deployment is enabled, the Micro Integrator will allow you to dynamically deploy artifacts without restarting the server.</p>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Purpose
This PR will add the necessary documentation to cover the below points about hot deployment in Micro Integrator.

- What is hot deployment
- When to use it
- When not to use it
- How to enable it