### PR TITLE
Fix links in Working with Proxy Servers page

### DIFF
--- a/en/micro-integrator/docs/setup/configuring_proxy_servers.md
+++ b/en/micro-integrator/docs/setup/configuring_proxy_servers.md
@@ -28,7 +28,7 @@ sender.secured_proxy_host = "<hostname/ip>"
 sender.secured_proxy_port = <port>
 ```
 
-See the complete list of [configuration parameters](/references/config-catalog/#https-transport-non-blocking-mode).
+See the complete list of [configuration parameters](../../references/config-catalog/#https-transport-non-blocking-mode).
 
 ### For blocking service calls
 
@@ -49,7 +49,7 @@ sender.secured_proxy_host = "<hostname/ip>"
 sender.secured_proxy_port = <port>
 ```
 
-See the complete list of [configuration parameters](/references/config-catalog/#https-transport-blocking-mode).
+See the complete list of [configuration parameters](../../references/config-catalog/#https-transport-blocking-mode).
 
 !!! Info
     **Bypass the proxy server for blocking calls?**


### PR DESCRIPTION
## Purpose
This PR fixes the "configuration parameters" link in the "Working with Proxy Servers" page in MI documentation.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes