### PR TITLE
Update payload based rounting example

### DIFF
--- a/en/micro-integrator/docs/use-cases/examples/routing_examples/routing_based_on_payloads.md
+++ b/en/micro-integrator/docs/use-cases/examples/routing_examples/routing_based_on_payloads.md
@@ -141,7 +141,7 @@ Invoke the proxy service:
       <soapenv:Body>
          <ser:getQuote xmlns:ser="http://services.samples" xmlns:xsd="http://services.samples/xsd">
             <ser:request>
-               <xsd:symbol>IBM</xsd:symbol>
+               <xsd:symbol>MSFT</xsd:symbol>
             </ser:request>
          </ser:getQuote>
       </soapenv:Body>


### PR DESCRIPTION
Correcting a value in the given payload. The payload of the second example should contain the symbol `MSFT`.

Doc: https://ei.docs.wso2.com/en/latest/micro-integrator/use-cases/examples/routing_examples/splitting_aggregating_messages/

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/844