### PR TITLE
Correcting ftp-mail example

### DIFF
--- a/en/micro-integrator/docs/use-cases/examples/protocol-switching/switching_from_FTP_listener_to_mail_sender.md
+++ b/en/micro-integrator/docs/use-cases/examples/protocol-switching/switching_from_FTP_listener_to_mail_sender.md
@@ -17,10 +17,12 @@ Following are the integration artifacts that we can used to implement this scena
     <target>
         <inSequence>
             <header name="Action" value="urn:getQuote"/>
+            <send>
+                <endpoint>
+                    <address uri="http://localhost:9000/services/SimpleStockQuoteService"/>
+                </endpoint>
+            </send>
         </inSequence>
-        <endpoint>
-            <address uri="http://localhost:9000/services/SimpleStockQuoteService"/>
-        </endpoint>
         <outSequence>
             <property action="set" name="OUT_ONLY" value="true"/>
             <send>


### PR DESCRIPTION
Correcting the synapse configuration.

Doc link: https://ei.docs.wso2.com/en/latest/micro-integrator/use-cases/examples/protocol-switching/switching_from_FTP_listener_to_mail_sender/

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/848