### PR TITLE
Fixing typos in http-fix example

### DIFF
--- a/en/micro-integrator/docs/use-cases/examples/protocol-switching/switching_from_HTTP_to_FIX.md
+++ b/en/micro-integrator/docs/use-cases/examples/protocol-switching/switching_from_HTTP_to_FIX.md
@@ -56,7 +56,7 @@ Send the following request to EI and we will receive the response from the execu
 
 ```bash
 curl -X POST \
-  http://lahiru-thinkpad-x1-carbon-4th:8290/services/HTTPToFIXProxy \
+  http://localhost:8290/services/HTTPToFIXProxy \
   -H 'cache-control: no-cache' \
   -H 'content-type: text/xml' \
   -H 'soapaction: \"urn:mediate\"' \
@@ -81,5 +81,5 @@ curl -X POST \
          <trailer />
       </message>
    </soapenv:Body>
-</soapenv:Envelope>
+</soapenv:Envelope>'
 ```


### PR DESCRIPTION
Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/848