### PR TITLE
Improve RestAPI example

### DIFF
--- a/en/micro-integrator/docs/use-cases/examples/rest_api_examples/introduction-rest-api.md
+++ b/en/micro-integrator/docs/use-cases/examples/rest_api_examples/introduction-rest-api.md
@@ -69,28 +69,61 @@ Set up the back-end service:
 
 Invoke the sample Api:
 
-1. Save the following sample request as `placeorder.xml` in your local file system. 
-
+1. Sending a GET request
+   
+   Open a terminal and execute the following command. This sends a simple GET request to the Micro Integrator.
+        
     ```bash
-    <placeOrder xmlns="http://services.samples">
-      <order>
-         <price>50</price>
-         <quantity>10</quantity>
-         <symbol>IBM</symbol>
-      </order>
-    </placeOrder>
+    curl http://127.0.0.1:8290/stockquote/view/IBM
     ```
-
-2.  Open a terminal, navigate to the location of your `placeorder.xml` file, and execute the following command. This posts a simple XML request to the Micro Integrator.
-
-    ```bash
-    curl -v -d @placeorder.xml -H "Content-type: application/xml" http://127.0.0.1:8290/stockquote/order/
-    ```
-
-    The Micro Integrator returns the 202 response back to the client.
+    
+    The Micro Integrator returns the following response back to the client.
 
     ```xml
-    < HTTP/1.1 202 Accepted
-    < Date: Wed, 30 Oct 2019 05:33:49 GMT
-    < Transfer-Encoding: chunked
+    <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns="http://services.samples" xmlns:ax21="http://services.samples/xsd">
+        <soapenv:Body>
+            <ns:getQuoteResponse>
+                    <ax21:change>-2.86843917118114</ax21:change>
+                    <ax21:earnings>-8.540305401672558</ax21:earnings>
+                    <ax21:high>-176.67958828498735</ax21:high>
+                    <ax21:last>177.66987465262923</ax21:last>
+                    <ax21:low>-176.30898912339075</ax21:low>
+                    <ax21:marketCap>5.649557998178506E7</ax21:marketCap>
+                    <ax21:name>IBM Company</ax21:name>
+                    <ax21:open>185.62740369461244</ax21:open>
+                    <ax21:peRatio>24.341353665128693</ax21:peRatio>
+                    <ax21:percentageChange>-1.4930577008849097</ax21:percentageChange>
+                    <ax21:prevClose>192.11844053187397</ax21:prevClose>
+                    <ax21:symbol>IBM</ax21:symbol>
+                    <ax21:volume>7791</ax21:volume>
+            </ns:getQuoteResponse>
+        </soapenv:Body>
+    </soapenv:Envelope>
     ```
+
+2. Sending a POST request
+    1. Save the following sample request as `placeorder.xml` in your local file system. 
+    
+        ```bash
+        <placeOrder xmlns="http://services.samples">
+          <order>
+             <price>50</price>
+             <quantity>10</quantity>
+             <symbol>IBM</symbol>
+          </order>
+        </placeOrder>
+        ```
+    
+    2.  Open a terminal, navigate to the location of your `placeorder.xml` file, and execute the following command. This posts a simple XML request to the Micro Integrator.
+    
+        ```bash
+        curl -v -d @placeorder.xml -H "Content-type: application/xml" http://127.0.0.1:8290/stockquote/order/
+        ```
+    
+        The Micro Integrator returns the 202 response back to the client.
+    
+        ```xml
+        < HTTP/1.1 202 Accepted
+        < Date: Wed, 30 Oct 2019 05:33:49 GMT
+        < Transfer-Encoding: chunked
+        ```

--- a/en/micro-integrator/docs/use-cases/examples/rest_api_examples/introduction-rest-api.md
+++ b/en/micro-integrator/docs/use-cases/examples/rest_api_examples/introduction-rest-api.md
@@ -69,7 +69,7 @@ Set up the back-end service:
 
 Invoke the sample Api:
 
-1. Sending a GET request
+-  Sending a GET request.
    
    Open a terminal and execute the following command. This sends a simple GET request to the Micro Integrator.
         
@@ -77,7 +77,7 @@ Invoke the sample Api:
     curl http://127.0.0.1:8290/stockquote/view/IBM
     ```
     
-    The Micro Integrator returns the following response back to the client.
+    The Micro Integrator returns the following response to the client.
 
     ```xml
     <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns="http://services.samples" xmlns:ax21="http://services.samples/xsd">
@@ -101,7 +101,7 @@ Invoke the sample Api:
     </soapenv:Envelope>
     ```
 
-2. Sending a POST request
+-  Sending a POST request.
     1. Save the following sample request as `placeorder.xml` in your local file system. 
     
         ```bash


### PR DESCRIPTION
Adding a missing REST call to the restAPI introduction example.

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/861