### PR TITLE
Adding missing details to secure restAPI example

### DIFF
--- a/en/micro-integrator/docs/use-cases/examples/rest_api_examples/securing-rest-apis.md
+++ b/en/micro-integrator/docs/use-cases/examples/rest_api_examples/securing-rest-apis.md
@@ -90,6 +90,8 @@ Test the API:
     ```bash
     curl -v http://127.0.0.1:8290/stockquote/view/IBM -H "Authorization: Basic YWRtaW46YWRtaW4="
     ```
+    !!! Info
+            In the authorization header `Authorization: Basic YWRtaW46YWRtaW4=`, credential `YWRtaW46YWRtaW4=` is the Base64 encoded username and password in the format `username:password`.
 
     The request is passed to the back-end service and you will receive a response similar to what is shown below:
 

--- a/en/micro-integrator/docs/use-cases/examples/rest_api_examples/securing-rest-apis.md
+++ b/en/micro-integrator/docs/use-cases/examples/rest_api_examples/securing-rest-apis.md
@@ -91,7 +91,7 @@ Test the API:
     curl -v http://127.0.0.1:8290/stockquote/view/IBM -H "Authorization: Basic YWRtaW46YWRtaW4="
     ```
     !!! Info
-            In the authorization header `Authorization: Basic YWRtaW46YWRtaW4=`, credential `YWRtaW46YWRtaW4=` is the Base64 encoded username and password in the format `username:password`.
+         Note that the credentials (`YWRtaW46YWRtaW4=`) given in the authorization header (`Authorization: Basic YWRtaW46YWRtaW4=`) are the Base64-encoded username and password in the following format: `username:password`.
 
     The request is passed to the back-end service and you will receive a response similar to what is shown below:
 


### PR DESCRIPTION
## Purpose
Include details on how the credentials in the header are formed.

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/861