### PR TITLE
Update example- sequence as local entry

### DIFF
--- a/en/micro-integrator/docs/use-cases/examples/registry_examples/local-registry-entries.md
+++ b/en/micro-integrator/docs/use-cases/examples/registry_examples/local-registry-entries.md
@@ -1,5 +1,5 @@
 # Sequences and Endpoints as Local Registry Entries
-This sample demonstrates how sequences and endpoints can be fetched from a local registry so that it is possible to have the sequences and endpoints as local registry entries.
+This sample demonstrates how sequences and endpoints can be fetched from a local registry.
 
 ## Synapse configurations
 
@@ -61,6 +61,6 @@ Set up the back-end service:
 
 Send a message to invoke the service and analyze the mediation log on the Micro Integrator's start-up console.
 
-You will see that the sequence and the endpoint are fetched from the local entry and property `direction` set by the proxy is logged by the sequence.
+You will see that the sequence and the endpoint are fetched from the local entry and that the property named `direction` (which was set by the proxy service) is logged by the sequence.
 
 `INFO {org.apache.synapse.mediators.builtin.LogMediator} - Text = Sending quote request, direction = incoming`

--- a/en/micro-integrator/docs/use-cases/examples/registry_examples/local-registry-entries.md
+++ b/en/micro-integrator/docs/use-cases/examples/registry_examples/local-registry-entries.md
@@ -1,7 +1,5 @@
 # Sequences and Endpoints as Local Registry Entries
-This sample demonstrates the functionality of local registry entry definitions, reusable endpoints, and sequences. This example uses a sequence named *main* that specifies the main mediation rules to be executed. This is equivalent to directly
-specifying the mediators of the main sequence within the `\<definitions\>` tag. This sample scenario is a
-recommended approach for non-trivial configurations.
+This sample demonstrates how sequences and endpoints can be fetched from a local registry so that it is possible to have the sequences and endpoints as local registry entries.
 
 ## Synapse configurations
 
@@ -27,7 +25,6 @@ Following are the integration artifacts that we can used to implement this scena
     <!-- log the message using the custom log level. illustrates custom properties for log -->
     <log level="custom">
         <property name="Text" value="Sending quote request"/>
-        <property expression="get-property('version')" name="version"/>
         <property expression="get-property('direction')" name="direction"/>
     </log>
     <!-- send message to real endpoint referenced by key "simple" endpoint definition -->
@@ -49,8 +46,9 @@ Create the artifacts:
 
 1. [Set up WSO2 Integration Studio](../../../../develop/installing-WSO2-Integration-Studio).
 2. [Create an ESB Solution project](../../../../develop/creating-projects/#esb-config-project)
-3. Create the [proxy service](../../../../develop/creating-artifacts/creating-a-proxy-service), [sequence](../../../../develop/creating-artifacts/creating-reusable-sequences), and [endpoint](../../../../develop/creating-artifacts/creating-an-endpoint) with the configurations given above.
-4. [Deploy the artifacts](../../../../develop/deploy-and-run) in your Micro Integrator.
+3. Create sequence `stockquote` and endpoint `simple` as [local entries](../../../../develop/creating-artifacts/registry/creating-local-registry-entries) with the configurations given above.
+4. Also, create the [proxy service](../../../../develop/creating-artifacts/creating-a-proxy-service) `MainProxy` with the configuration given above.
+5. [Deploy the artifacts](../../../../develop/deploy-and-run) in your Micro Integrator.
 
 Set up the back-end service:
 
@@ -63,28 +61,6 @@ Set up the back-end service:
 
 Send a message to invoke the service and analyze the mediation log on the Micro Integrator's start-up console.
 
-You will see that a sequence named *main* is executed. Then, for the
-incoming message flow, the *stockquote* sequence is called.
+You will see that the sequence and the endpoint are fetched from the local entry and property `direction` set by the proxy is logged by the sequence.
 
-```bash
-DEBUG SequenceMediator - Sequence mediator <main> :: mediate()
-DEBUG InMediator - In mediator mediate()
-DEBUG SequenceMediator - Sequence mediator <stockquote> :: mediate()
-```
-
-The log mediator dumps a simple *text/string* property, which is the
-result of an XPath evaluation that picks up the *version* key
-and a second result of an XPath evaluation that picks up a local message
-property set previously by the property mediator. The
-`         get-property()        ` XPath extension function is able to
-read message properties local to the current message, local or remote
-registry entries, Axis2 message context properties as well as transport
-headers. The local entry definition for *version* defines a simple
-*text/string* registry entry, which is visible to all messages that pass
-through the Micro Integrator.
-
-```bash
-[HttpServerWorker-1] INFO LogMediator - Text = Sending quote request, version = 0.1, direction = incoming
-[HttpServerWorker-1] DEBUG SendMediator - Send mediator :: mediate()
-[HttpServerWorker-1] DEBUG AddressEndpoint - Sending To: http://localhost:9000/services/SimpleStockQuoteService
-```
+`INFO {org.apache.synapse.mediators.builtin.LogMediator} - Text = Sending quote request, direction = incoming`


### PR DESCRIPTION
1. Removed `definitions` related details as it is not used.
2. Updated some of the content following the doc from [EI-6.6.0](https://docs.wso2.com/display/EI660/Sample+14%3A+Using+Sequences+and+Endpoints+as+Local+Registry+Items)

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/868