### PR TITLE
Fix example address endpoint

### DIFF
--- a/en/micro-integrator/docs/use-cases/examples/endpoint_examples/using-address-endpoints.md
+++ b/en/micro-integrator/docs/use-cases/examples/endpoint_examples/using-address-endpoints.md
@@ -24,9 +24,7 @@ Following is a sample REST API configuration that we can used to implement this 
                  <else/>
              </filter>
          </inSequence>
-         <outSequence>
-             <call/>
-         </outSequence>
+         <outSequence/>
          <faultSequence/>
      </target>
 </proxy>


### PR DESCRIPTION
Removing the outsequence as insequence contains a respond mediator

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/870