### PR TITLE
Fix example failover endpoint

### DIFF
--- a/en/micro-integrator/docs/use-cases/examples/endpoint_examples/using-failover-endpoints.md
+++ b/en/micro-integrator/docs/use-cases/examples/endpoint_examples/using-failover-endpoints.md
@@ -17,7 +17,7 @@ Following is a sample REST API configuration that we can used to implement this 
             <endpoint name="SampleFailover">
                 <failover>
                     <endpoint name="Sample_First" statistics="enable" >
-                        <address uri="http://localhost/myendpoint" statistics="enable" trace="disable">
+                        <address uri="http://localhost:123/myendpoint" statistics="enable" trace="disable">
                             <timeout>
                                 <duration>60000</duration>
                             </timeout>
@@ -152,7 +152,7 @@ Multiple address endpoints are used in this example.
                                 <maximumDuration>30000</maximumDuration>
                             </suspendOnFailure>
                             <retryConfig>
-                                <disabledErrorCodes>101507,101504</disabledErrorCodes>
+                                <disabledErrorCodes>101507,101503</disabledErrorCodes>
                             </retryConfig>
                         </http>
                     </endpoint>


### PR DESCRIPTION
1. In the first synapse configuration, add a dummy port to the address. This is because windows send an HTML reply with "Not found server" message when connecting to an invalid address without a port.
   Then the MI does not pick the correct error code.
2. In the 2nd synapse config, changed the error code as it is the one returned and needed to capture to break the loop

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/870