### PR TITLE
Update ActiveMQ configuration doc

### DIFF
--- a/en/micro-integrator/docs/setup/brokers/configure-with-ActiveMQ.md
+++ b/en/micro-integrator/docs/setup/brokers/configure-with-ActiveMQ.md
@@ -49,6 +49,11 @@ Follow the instructions below to set up and configure.
         parameter.connection_factory_type = "queue"
         parameter.cache_level = "consumer"
         ```        
+    !!! Note
+        When configuring the jms listener, be sure to add the connection factory [service-level jms parameter](../../references/synapse-properties/transport-parameters/jms-transport-parameters.md) to the synapse configuration with the name of the already defined connection factory.
+        ```xml
+        <parameter name="transport.jms.ConnectionFactory">myQueueListener</parameter>
+        ```
 
     - Add the following configurations to enable the JMS sender with ActiveMQ connection parameters.
         ```toml

--- a/en/micro-integrator/docs/setup/installation/run_in_docker.md
+++ b/en/micro-integrator/docs/setup/installation/run_in_docker.md
@@ -35,12 +35,29 @@ Two types of base Docker images are available for the Micro Integrator:
 
 -   The community version of WSO2 Micro Integrator's base Docker image is
     available on [DockerHub](https://hub.docker.com/r/wso2/micro-integrator).
-
-    **Base Docker Image and Tag (community version)**
-
+    
     ```bash
-    wso2/micro-integrator:1.1.0
+    wso2/micro-integrator:latest
     ```
+    
+    !!! Note
+        The following Docker Images are available from Micro Integrator v1.2.0 onwards.
+        
+        If you need the most lightweight version of micro integrator, you may find the minimal Docker image based on Alpine Linux which is coming by default.
+    
+        **Base Docker Image and Tag (community version)**
+    
+        ```bash
+        wso2/micro-integrator:1.x.x
+        ```
+        Additionally, Micro Integrator Docker images based on Ubuntu(v18.04) and CentOS(v7) are also available on DockerHub with the following corresponding tags. 
+        
+        ```bash
+        wso2/micro-integrator:1.x.x-ubuntu18.04
+        ```
+        ```bash
+        wso2/micro-integrator:1.x.x-centos7
+        ```
 
 ## Run on Docker using WSO2 Integration Studio
 


### PR DESCRIPTION
## Purpose
```
[[transport.jms.listener]]
name = "myQueueListener"
.
.
.
```
When configuring the proxy service (JMS listener), it is a must to add the following connection factory with the name of the already defined connection factory in the deployment.toml file.
```
<parameter name="transport.jms.ConnectionFactory">myQueueListener</parameter>
```

Otherwise, the listener proxy will not work unless we put the JMS connection factory name as "default" in the deployment.toml file.

```
[[transport.jms.listener]]
name = "default"
.
.
.
```