### PR TITLE
Fix example wsdl endpoint

### DIFF
--- a/en/micro-integrator/docs/use-cases/examples/endpoint_examples/using-wsdl-endpoints.md
+++ b/en/micro-integrator/docs/use-cases/examples/endpoint_examples/using-wsdl-endpoints.md
@@ -16,7 +16,7 @@ Following is a sample REST API configuration that we can used to implement this 
             <call>
                 <endpoint>
                     <wsdl uri="file:/path/to/sample_proxy_1.wsdl"
-                        service="SimpleStockQuoteService" port="SimpleStockQuoteServiceHttpSoap11Endpoint"/>
+                        service="SimpleStockQuoteService" port="SimpleStockQuoteServiceHttpSoapDefaultEndpoint"/>
                 </endpoint>
             </call>
             <respond/>
@@ -100,8 +100,8 @@ in above sample is given below.
 
 ```xml
 <wsdl:service name="SimpleStockQuoteService">
-   <wsdl:port name="SimpleStockQuoteServiceHttpSoap11Endpoint" binding="ns:SimpleStockQuoteServiceSoap11Binding">
-            <soap:address location="http://localhost:9000/services/SimpleStockQuoteService.SimpleStockQuoteServiceHttpSoap11Endpoint"/>
+   <wsdl:port name="SimpleStockQuoteServiceHttpSoapDefaultEndpoint" binding="ns:SimpleStockQuoteServiceSoap11Binding">
+            <soap:address location="http://localhost:9000/services/SimpleStockQuoteService"/>
    </wsdl:port>
    <wsdl:port name="SimpleStockQuoteServiceHttpSoap12Endpoint" binding="ns:SimpleStockQuoteServiceSoap12Binding">
             <soap12:address location="http://localhost:9000/services/SimpleStockQuoteService.SimpleStockQuoteServiceHttpSoap12Endpoint"/>
@@ -111,4 +111,4 @@ in above sample is given below.
 
 According to the above WSDL, the service and port specified in the
 configuration refers to the endpoint address:
-`http://localhost:9000/services/SimpleStockQuoteService.SimpleStockQuoteServiceHttpSoap11Endpoint`
+`http://localhost:9000/services/SimpleStockQuoteService`


### PR DESCRIPTION
Add a new entry to the WSDL file as the existing one are cannot be found when running. Changing the synapse configurations and others accordingly.

Related PR (Adding a new port in the WSDL file): https://github.com/wso2-docs/WSO2_EI/pull/68

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/870