### PR TITLE
Improving Inject Msg to RestFul example

### DIFF
--- a/en/micro-integrator/docs/use-cases/examples/scheduled-tasks/injecting-messages-to-rest-endpoint.md
+++ b/en/micro-integrator/docs/use-cases/examples/scheduled-tasks/injecting-messages-to-rest-endpoint.md
@@ -55,13 +55,5 @@ Create the artifacts:
 3. Create the [proxy service](../../../../develop/creating-artifacts/creating-a-proxy-service) and a [scheduled task](../../../../develop/creating-artifacts/creating-scheduled-task) with the configurations given above.
 4. [Deploy the artifacts](../../../../develop/deploy-and-run) in your Micro Integrator.
 
-Set up the back-end service:
-
-1. Download the [stockquote_service.jar](https://github.com/wso2-docs/WSO2_EI/blob/master/Back-End-Service/stockquote_service.jar).
-2. Open a terminal, navigate to the location of the downloaded service, and run it using the following command:
-
-    ```bash
-    java -jar stockquote_service.jar
-    ```
-
-The XML message you injected (i.e., `<abc>This is a scheduled task of the default implementation.</abc>`) will be printed in the logs of the Micro Integrator every 5 seconds.
+The following log will be printed each time a message is injected.
+`INFO {org.apache.synapse.mediators.builtin.LogMediator} - Which city? = London, Which country? = UK`

--- a/en/micro-integrator/docs/use-cases/examples/scheduled-tasks/injecting-messages-to-rest-endpoint.md
+++ b/en/micro-integrator/docs/use-cases/examples/scheduled-tasks/injecting-messages-to-rest-endpoint.md
@@ -55,5 +55,8 @@ Create the artifacts:
 3. Create the [proxy service](../../../../develop/creating-artifacts/creating-a-proxy-service) and a [scheduled task](../../../../develop/creating-artifacts/creating-scheduled-task) with the configurations given above.
 4. [Deploy the artifacts](../../../../develop/deploy-and-run) in your Micro Integrator.
 
-The following log will be printed each time a message is injected.
-`INFO {org.apache.synapse.mediators.builtin.LogMediator} - Which city? = London, Which country? = UK`
+The XML message you injected (i.e., This is a scheduled task of the default implementation.) will be printed in the logs of the Micro Integrator twice, 5 seconds apart.
+
+```bash
+INFO {org.apache.synapse.mediators.builtin.LogMediator} - Which city? = London, Which country? = UK
+```


### PR DESCRIPTION
1.  Removing details on setting up a back-end as this example does not use a back-end.
2.  Correcting the log.
