### PR TITLE
Update ActiveMQ configuration doc

### DIFF
--- a/en/micro-integrator/docs/setup/brokers/configure-with-ActiveMQ.md
+++ b/en/micro-integrator/docs/setup/brokers/configure-with-ActiveMQ.md
@@ -49,6 +49,11 @@ Follow the instructions below to set up and configure.
         parameter.connection_factory_type = "queue"
         parameter.cache_level = "consumer"
         ```        
+    !!! Note
+        When configuring the jms listener, be sure to add the connection factory [service-level jms parameter](../../references/synapse-properties/transport-parameters/jms-transport-parameters.md) to the synapse configuration with the name of the already defined connection factory.
+        ```xml
+        <parameter name="transport.jms.ConnectionFactory">myQueueListener</parameter>
+        ```
 
     - Add the following configurations to enable the JMS sender with ActiveMQ connection parameters.
         ```toml


### PR DESCRIPTION
## Purpose
```
[[transport.jms.listener]]
name = "myQueueListener"
.
.
.
```
When configuring the proxy service (JMS listener), it is a must to add the following connection factory with the name of the already defined connection factory in the deployment.toml file.
```
<parameter name="transport.jms.ConnectionFactory">myQueueListener</parameter>
```

Otherwise, the listener proxy will not work unless we put the JMS connection factory name as "default" in the deployment.toml file.

```
[[transport.jms.listener]]
name = "default"
.
.
.
```