### PR TITLE
Update Custom message formatter sample

### DIFF
--- a/en/micro-integrator/docs/setup/message_builders_formatters/message-builders-and-formatters.md
+++ b/en/micro-integrator/docs/setup/message_builders_formatters/message-builders-and-formatters.md
@@ -231,12 +231,12 @@ outgoing payload from the WSO2 Micro Integrator.
 
 When creating a custom message formatter, you will need to create a class implementing the `org.apache.axis2.transport.MessageFormatter` interface and then override the `writeTo` method. You can implement your logic within the `writeTo` method.
 
-To enable your custom message formatter for content type text/xml, add the following line in the deployment.toml file:
+Let `org.apache.axis2.transport.http.HTMLMessageFormatter` be the class that implements the `org.apache.axis2.transport.MessageFormatter` interface. To enable this custom message formatter for content type text/html, add the following line in the deployment.toml file:
 
 ```toml
-[[custom_message_builders]]
-content_type = "text/xml"
-class="org.apache.axis2.transport.http.SOAPMessageFormatter"
+[[custom_message_formatters]]
+content_type = "text/html"
+class="org.apache.axis2.transport.http.HTMLMessageFormatter"
 ```
 
 The class name used in the above line should be the name used for the class when writing the formatter.

--- a/en/micro-integrator/docs/setup/message_builders_formatters/message-builders-and-formatters.md
+++ b/en/micro-integrator/docs/setup/message_builders_formatters/message-builders-and-formatters.md
@@ -229,9 +229,9 @@ processed in the WSO2 Micro Integrator mediation flow.
 Similarly, you can write your own message formatter to manipulate the
 outgoing payload from the WSO2 Micro Integrator.
 
-When creating a custom message formatter, you will need to create a class implementing the `org.apache.axis2.transport.MessageFormatter` interface and then override the `writeTo` method. You can implement your logic within the `writeTo` method.
+When creating a custom message formatter, you will need to create a class implementing the `org.apache.axis2.transport.MessageFormatter` interface and then override the `writeTo` method. You can implement your logic within the `writeTo` method. Let's use the `org.apache.axis2.transport.http.HTMLMessageFormatter` class to implement the `org.apache.axis2.transport.MessageFormatter` interface. 
 
-Let `org.apache.axis2.transport.http.HTMLMessageFormatter` be the class that implements the `org.apache.axis2.transport.MessageFormatter` interface. To enable this custom message formatter for content type text/html, add the following line in the deployment.toml file:
+To enable this custom message formatter for content type `text/html`, add the following configuration to the `deployment.toml` file:
 
 ```toml
 [[custom_message_formatters]]


### PR DESCRIPTION
## Purpose
$subject

Whatever the content-type that we put under [custom_message_builders] or [custom_message_formatters] should be the ones that do not have a default message formatter or builder specified in axis2.xml (i.e. templated through axis2.xml.j2). [Here](https://github.com/wso2/micro-integrator/issues/1347#issuecomment-611947999) is a reference to the summary of the existing message formatters and builders templated in axis2.xml.j2 as per the date of this PR.