### PR TITLE
Fix project typo in Composite Application Project section.

### DIFF
--- a/en/micro-integrator/docs/develop/creating-projects.md
+++ b/en/micro-integrator/docs/develop/creating-projects.md
@@ -93,7 +93,7 @@ Create this project directory if you have used ESB connectors in your medition s
 
 ## Composite Application Project
 
-This poject directory allows you to package all the artifacts (stored in other ESB projects) into one composite application (C-APP). This C-APP can then be deployed in the ESB server. See the instructions on packaging ESB artifacts.
+This project directory allows you to package all the artifacts (stored in other ESB projects) into one composite application (C-APP). This C-APP can then be deployed in the ESB server. See the instructions on packaging ESB artifacts.
 
 <!--
 <table>


### PR DESCRIPTION
## Purpose
Fix typo, poject -> project

## Documentation
https://ei.docs.wso2.com/en/latest/micro-integrator/develop/creating-projects/#composite-application-project
