### PR TITLE
Remove white space from Managing the growth of Carbon logs section.

### DIFF
--- a/en/micro-integrator/docs/administer-and-observe/logs/managing_log_growth.md
+++ b/en/micro-integrator/docs/administer-and-observe/logs/managing_log_growth.md
@@ -12,7 +12,7 @@ Log growth in [Carbon logs](../monitoring_logs/#carbon-logs) can be managed by t
 -   **Log rotation based on time as opposed to size**: This helps to inspect the events that occurred during a specific time.
 -   Log files are archived to maximise the use of space.
 
-The log4j2- based logging mechanism uses appenders to
+The log4j2-based logging mechanism uses appenders to
 append all the log messages into a file. That is, at the end of the log
 rotation period, a new file will be created with the appended logs and
 archived. The name of the archived log file will always contain the date


### PR DESCRIPTION
## Purpose
Remove white space - "log4j2- based" -> "log4j2-based"

## Documentation
https://ei.docs.wso2.com/en/latest/micro-integrator/administer-and-observe/logs/managing_log_growth/#managing-the-growth-of-carbon-logs

