### PR TITLE
Fix Prometheus documentation link.

### DIFF
--- a/en/micro-integrator/docs/administer-and-observe/monitoring_with_prometheus.md
+++ b/en/micro-integrator/docs/administer-and-observe/monitoring_with_prometheus.md
@@ -1,6 +1,6 @@
 # Monitoring with Prometheus
 
-Prometheus is an open source toolkit that can monitor systems and produce useful information such as graphs and alerts. It collects statistical data exposed over an HTTP endpoint in the form of multi dimensional time series data, which can be then be visualized and queried. See the [Prometheus documentation](http://prometheus%202) for more information.
+Prometheus is an open source toolkit that can monitor systems and produce useful information such as graphs and alerts. It collects statistical data exposed over an HTTP endpoint in the form of multi dimensional time series data, which can be then be visualized and queried. See the [Prometheus documentation](https://prometheus.io/docs/introduction/overview/) for more information.
 
 ## Overview
 


### PR DESCRIPTION
## Purpose
Update broken link 'http://prometheus%202' to 'https://prometheus.io/docs/introduction/overview/'

## Documentation
https://ei.docs.wso2.com/en/latest/micro-integrator/administer-and-observe/monitoring_with_prometheus/
