### PR TITLE
Align nav item with page title. Remove duplicated text in description.

### DIFF
--- a/en/micro-integrator/docs/references/mediators/aggregate-Mediator.md
+++ b/en/micro-integrator/docs/references/mediators/aggregate-Mediator.md
@@ -1,7 +1,7 @@
 # Aggregate Mediator
 
 The **Aggregate mediator** implements the [Aggregator enterprise integration pattern](https://docs.wso2.com/display/EIP/Aggregator). It
-combines (aggregates) the **response messages** of messages that were split by the split by the [Clone](clone-Mediator.md) or
+combines (aggregates) the **response messages** of messages that were split by the [Clone](clone-Mediator.md) or
 [Iterate](iterate-Mediator.md) mediator. Note that the responses are not necessarily aggregated in the same order that the requests were sent,
 even if you set the `         sequential        ` attribute to `         true        ` on the Iterate mediator.
 

--- a/en/micro-integrator/mkdocs.yml
+++ b/en/micro-integrator/mkdocs.yml
@@ -581,7 +581,7 @@ nav:
       - Synapse Configurations:
         - Mediator Catalog:
           - 'About Mediators': 'references/mediators/about-mediators.md'
-          - 'Aggregate Mediators' : 'references/mediators/aggregate-Mediator.md'
+          - 'Aggregate Mediator' : 'references/mediators/aggregate-Mediator.md'
           - 'Builder Mediator' : 'references/mediators/builder-Mediator.md'
           - 'Cache Mediator' : 'references/mediators/cache-Mediator.md'
           - 'Call Mediator' : 'references/mediators/call-Mediator.md'


### PR DESCRIPTION
## Purpose
Align nav item 'Aggregate Mediators' -> 'Aggregate Mediator' with page title 'Aggregate Mediator'

Remove duplicated text - 'were split by the _split by the_ '

## Documentation
https://ei.docs.wso2.com/en/latest/micro-integrator/references/mediators/aggregate-Mediator/
