### PR TITLE
Change File name and Menu name to 'Pipeline Quick Start Guide'

### DIFF
--- a/en/micro-integrator/docs/setup/deployment/k8s-pipeline/adding-test-cases.md
+++ b/en/micro-integrator/docs/setup/deployment/k8s-pipeline/adding-test-cases.md
@@ -7,7 +7,7 @@ Often it is faster and simpler to perform local unit testing on your pipeline co
 This guide assumes that you have completed the instructions in the
 following pages.
 
-1.  [Quick Start Guide](../quick-start-guide/)
+1.  [Pipeline Quick Start Guide](../pipeline-quick-start-guide/)
 
 2.  [Testing The Pipeline
     Environment](../testing-the-pipeline-environment/)
@@ -59,8 +59,8 @@ directory named `tests`.
 
 5.  Change the chart repository in the
     sample [values](https://raw.githubusercontent.com/wso2/kubernetes-pipeline/master/samples/values-mi.yaml) file
-    used in the [Quick Start
-    Guide](../quick-start-guide/)
+    used in the [Pipeline Quick Start
+    Guide](../pipeline-quick-start-guide/)
     to use a custom chart.
     
     ``` xml

--- a/en/micro-integrator/docs/setup/deployment/k8s-pipeline/deploy-your-own-artifact.md
+++ b/en/micro-integrator/docs/setup/deployment/k8s-pipeline/deploy-your-own-artifact.md
@@ -7,7 +7,7 @@ This is done by providing a custom Dockerfile as shown in the steps below:
     project](../../../../develop/create-integration-project/).
 
 2.  Update the repositories in the  [sample values](https://raw.githubusercontent.com/wso2/kubernetes-pipeline/master/samples/values-mi.yaml) file
-    used in the  [Quick Start Guide](../quick-start-guide/) to
+    used in the  [Pipeline Quick Start Guide](../pipeline-quick-start-guide/) to
     include the forked repository in place of `[git-username]` as
     highlighted below.
     

--- a/en/micro-integrator/docs/setup/deployment/k8s-pipeline/modifying-product-configurations.md
+++ b/en/micro-integrator/docs/setup/deployment/k8s-pipeline/modifying-product-configurations.md
@@ -5,7 +5,7 @@
 This document assumes that you have completed the instructions in the
 following pages.
 
-1.  [Quick Start Guide](../quick-start-guide/)
+1.  [Pipeline Quick Start Guide](../pipeline-quick-start-guide/)
 
 2.  [Testing The Pipeline Environment](../testing-the-pipeline-environment/)
 
@@ -39,8 +39,8 @@ Replace the `[git-username]` tag with the name of your GitHub username.
     
     2.  Change the chart data in the
         sample [values](https://raw.githubusercontent.com/wso2/kubernetes-pipeline/master/samples/values-mi.yaml) file
-        used in the [Quick Start
-        Guide](../quick-start-guide/) to
+        used in the [Pipeline Quick Start
+        Guide](../pipeline-quick-start-guide/) to
         use in the custom chart.
         
         ``` xml
@@ -70,8 +70,8 @@ Replace the `[git-username]` tag with the name of your GitHub username.
         
         
    **<RELEASE\_NAME\>** should be replaced with the release name
-        provided when the pipeline is installed initially in the [Quick Start
-        Guide](../quick-start-guide/).
+        provided when the pipeline is installed initially in the [Pipeline Quick Start
+        Guide](../pipeline-quick-start-guide/).
    
    4.  Restart the Jenkins pod by deleting the existing pod. This will
         cause the cluster to spawn a new pod for Jenkins.

--- a/en/micro-integrator/docs/setup/deployment/k8s-pipeline/pipeline-quick-start-guide.md
+++ b/en/micro-integrator/docs/setup/deployment/k8s-pipeline/pipeline-quick-start-guide.md
@@ -1,4 +1,4 @@
-# Quick Start Guide
+# Pipeline Quick Start Guide
 Setting up a basic pipeline for WSO2 Micro Integrator on Kubernetes is
 quick and simple.
 

--- a/en/micro-integrator/mkdocs.yml
+++ b/en/micro-integrator/mkdocs.yml
@@ -300,7 +300,7 @@ nav:
             - 'Sample 3: JMS Sender/Receiver': 'setup/deployment/k8s-samples/jms-sender-receiver.md'
           - K8s Pipeline:
             - 'Overview': 'setup/deployment/k8s-pipeline/overview.md'
-            - 'Quick Start Guide': 'setup/deployment/k8s-pipeline/quick-start-guide.md'
+            - 'Pipeline Quick Start Guide': 'setup/deployment/k8s-pipeline/pipeline-quick-start-guide.md'
             - 'Testing the Pipeline Environment': 'setup/deployment/k8s-pipeline/testing-the-pipeline-environment.md'
             - 'Deploy Your Own Artifact': 'setup/deployment/k8s-pipeline/deploy-your-own-artifact.md'
             - 'Adding Testcases': 'setup/deployment/k8s-pipeline/adding-test-cases.md'


### PR DESCRIPTION
## Purpose
> The purpose of changing the Quick start guide name was because the MI documentation itself comprised of its QSG therefore to alleviate any confusion this action was taken

## Goals
> By changing the pipeline QSG to be renamed to 'Pipeline Quick start guide' there won't be any confusion for the user when searched for it in total search in the site and it brings clarity when searched through the browser.

