### PR TITLE
Remove Prometheus obsolete link

### DIFF
--- a/en/micro-integrator/docs/administer-and-observe/observability-overview.md
+++ b/en/micro-integrator/docs/administer-and-observe/observability-overview.md
@@ -87,7 +87,6 @@ You can integrate with external tools to do the following.
 
 - [JMX Monitoring](jmx_monitoring.md)
 - [SNMP Monitoring](snmp_monitoring.md)
-- [Prometheus for Monitoring](monitoring_with_prometheus.md)
 
 **TCP Message Monitoring**
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Prometheus doc is no longer available in 7.1.0 (https://github.com/wso2/docs-ei/pull/2304). Hence, removing the obsolete link.