### PR TITLE
(7.1.0 branch) documentation on changing default ports

### DIFF
--- a/en/micro-integrator/docs/setup/changing_default_ports.md
+++ b/en/micro-integrator/docs/setup/changing_default_ports.md
@@ -69,9 +69,9 @@ There are two ways to manually offset the [default ports](#default-ports).
 
 !!! Tip
 	-	The internal offset of 10 is overriden by this manual offset. That is, if the manual offset is 3, the default ports will change as follows:
-		- `8293` -> `8290`
-		- `8253` -> `8250`
-		- `9164` -> `9161`
+		- `8290` -> `8283` (8290 - 10 + 3)
+		- `8253` -> `8246` (8253 - 10 + 3)
+		- `9164` -> `9157` (9164 - 10 + 3)
 	-	Note that if you manually set an offset of 10 using the following method, you will get the same [default ports](#default-ports).
 
 -   Pass the port offset to the server during startup.

--- a/en/micro-integrator/docs/setup/changing_default_ports.md
+++ b/en/micro-integrator/docs/setup/changing_default_ports.md
@@ -21,7 +21,7 @@ By default, the Micro Integrator is **internally** configured with a port offset
 			<code>8290</code>
 		</td>
 		<td>
-			HTTP Passthrough transport.
+			The port of the HTTP Passthrough transport.
 		</td>
 	</tr>
 	<tr>
@@ -29,7 +29,22 @@ By default, the Micro Integrator is **internally** configured with a port offset
 			<code>8253</code>
 		</td>
 		<td>
-			HTTPS Passthrough transport
+			The port of the HTTPS Passthrough transport.
+		</td>
+	</tr>
+	<tr>
+		<td>
+			<code>9201</code>
+		</td>
+		<td>
+			The HTTP port of the <a href="../../administer-and-observe/working-with-management-api">Management API</a> of WSO2 Micro Integrator.</br></br>
+			<b>Configuring the default HTTP port</b></br>
+			If required, you can manually change the HTTP port in the <code>deployment.toml</code> file (stored in the <code>MI_HOME/conf</code> folder) as shown below.</br></br>
+			<div>
+				<code>[mediation]</code></br>
+				<code>internal.http.api.port = http_port </code></br>
+			</div></br>
+			<b>Note</b>: With the default internal port offset, the effective port will be <code>http_port + 10</code>.
 		</td>
 	</tr>
 	<tr>
@@ -37,14 +52,14 @@ By default, the Micro Integrator is **internally** configured with a port offset
 			<code>9164</code>
 		</td>
 		<td>
-			The <a href="../../administer-and-observe/working-with-management-api">Management API</a> of WSO2 Micro Integrator is an internal REST API, which is used to obtain administrative information of the server instance.</br></br>
-			<b>Configuring the Management API port</b></br>
-			The Management API port can be configured in the <code>deployment.toml</code> file (stored in the <code>MI_HOME/conf</code> folder) as shown below.</br>
+			The HTTPS port of the <a href="../../administer-and-observe/working-with-management-api">Management API</a> of WSO2 Micro Integrator.</br></br>
+			<b>Configuring the default HTTPS port</b></br>
+			If required, you can manually change the HTTPS port in the <code>deployment.toml</code> file (stored in the <code>MI_HOME/conf</code> folder) as shown below.</br></br>
 			<div>
 				<code>[mediation]</code></br>
-				<code>internal_http_api_enable = true </code></br>
-				<code>internal_https_api_port = 9154 </code>
-			</div>
+				<code>internal_https_api_port = https_port </code>
+			</div></br>
+			<b>Note</b>: With the default internal port offset, the effective port will be <code>https_port + 10</code>.
 		</td>
 	</tr>
 </table>

--- a/en/micro-integrator/docs/setup/changing_default_ports.md
+++ b/en/micro-integrator/docs/setup/changing_default_ports.md
@@ -1,56 +1,55 @@
 # Changing the Default Ports
 
-When you run multiple WSO2 products, multiple instances of the same
-product, or multiple WSO2 product clusters on the same server or virtual
-machines (VMs), you must change their default ports with an offset value
-to avoid port conflicts. Port offset defines the number by which all
-ports defined in the runtime such as the HTTP/S ports will be changed.
-For example, if the default HTTP port is 9763 and the port offset is 1,
-the effective HTTP port will change to 9764. For each additional WSO2
-product instance, you set the port offset to a unique value.
+When you run multiple WSO2 Micro Integrator instances or a cluster of instances on a single server or virtual machine (VM),
+you must change the default ports to avoid port conflicts.
 
-## Setting a port offset
-The default port offset value is 10. There are two ways to set an offset
-to a port:
+## Default ports
 
--   Pass the port offset to the server during startup. The following
-    command (on MacOS) starts the server with the default port incremented by 3: `./micro-integrator.sh -DportOffset=3`
--   Open the `deployment.toml` file (stored in the `<MI_HOME>/conf` directory) and add the port offset as follows:
+By default, the Micro Integrator is **internally** configured with a port offset of 10. Listed below are the ports that are effective in the Micro Integrator by default (due to the internal port offset of 10).
 
-    ```toml
-    [server]
-    offset = 3
-    ```
+<table>
+	<tr>
+		<th>
+			Default Port
+		</th>
+		<th>
+			Description
+		</th>
+	</tr>
+	<tr>
+		<td>
+			<code>8290</code>
+		</td>
+		<td>
+			HTTP Passthrough transport.
+		</td>
+	</tr>
+	<tr>
+		<td>
+			<code>8253</code>
+		</td>
+		<td>
+			HTTPS Passthrough transport
+		</td>
+	</tr>
+	<tr>
+		<td>
+			<code>9164</code>
+		</td>
+		<td>
+			The <a href="../../administer-and-observe/working-with-management-api">Management API</a> of WSO2 Micro Integrator is an internal REST API, which is used to obtain administrative information of the server instance.</br></br>
+			<b>Configuring the Management API port</b></br>
+			The Management API port can be configured in the <code>deployment.toml</code> file (stored in the <code>MI_HOME/conf</code> folder) as shown below.</br>
+			<div>
+				<code>[mediation]</code></br>
+				<code>internal_http_api_enable = true </code></br>
+				<code>internal_https_api_port = 9154 </code>
+			</div>
+		</td>
+	</tr>
+</table>
 
-When you set the server-level port offset as shown above, all the ports used by the server will change automatically.
-
-## Default Ports of WSO2 Micro Integrator
-
-This page describes the default ports that are used for WSO2 Micro Integrator when the port offset is 0.
-
-### Passthrough transport ports
-
-Listed below are the default ports that are used in WSO2 Micro Integrator when the port offset is 10.
-
-- 8290: HTTP Passthrough transport
-- 8253: HTTPS Passthrough transport
-
-### Management API port
-
-The [Management API](../../administer-and-observe/working-with-management-api) of WSO2 Micro Integrator is an internal REST API, which is used to obtain administrative information of the server instance. The default port of the Management API used in WSO2 Micro Integrator when the port offset is 10:
-
--   9164: HTTPS Internal API port
-
-The Management API port can be configured in the `deployment.toml ` file (stored in the
-`         <MI_HOME>/conf        ` directory) as shown below. 
-
-```toml
-[mediation]
-internal_http_api_enable = true 
-internal_https_api_port = 9154 
-```
-
-### Random ports
+## Random ports
 
 Certain ports are randomly opened during server startup. This is due to
 specific properties and configurations that become effective when the
@@ -63,3 +62,31 @@ every time the server is started.
     JMX monitoring facility in JVM.
 -   A random UDP port is opened at server startup due to the log4j
     appender (`SyslogAppender`), which is configured in the `<MI_HOME>/conf/log4j2.properties` file.
+
+## Changing default ports
+
+There are two ways to manually offset the [default ports](#default-ports).
+
+!!! Tip
+	-	The internal offset of 10 is overriden by this manual offset. That is, if the manual offset is 3, the default ports will change as follows:
+		- `8293` -> `8290`
+		- `8253` -> `8250`
+		- `9164` -> `9161`
+	-	Note that if you manually set an offset of 10 using the following method, you will get the same [default ports](#default-ports).
+
+-   Pass the port offset to the server during startup.
+
+    ```bash tab='On MacOS/Linux/Centos'
+    ./micro-integrator.sh -DportOffset=3
+    ```
+
+    ```bash tab='On Windows'
+    micro-integrator.bat -DportOffset=3
+    ```
+
+-   Open the `deployment.toml` file (stored in the `MI_HOME/conf` folder) and add the port offset as follows:
+
+    ```toml
+    [server]
+    offset = 3
+    ```


### PR DESCRIPTION
Updating the documentation on default ports in the Micro Integrator to better explain the internal offset of 10, which is effective by default.