### PR TITLE
Update redis-connector-example.md

### DIFF
--- a/en/micro-integrator/docs/references/connectors/redis-connector/redis-connector-example.md
+++ b/en/micro-integrator/docs/references/connectors/redis-connector/redis-connector-example.md
@@ -38,6 +38,14 @@ Follow these steps to set up the Integration Project and the Connector Exporter 
 
 {!references/connectors/importing-connector-to-integration-studio.md!} 
 
+### Add the connector to the Connector Exporter project
+
+Follow these steps to add the Redis connector to the Connector Exporter project. This is needed to access the Redis connector and its operations at runtime.
+
+1. Right click on the connector exporter project and click on New-> Add/Remove Connectors.
+2. Then in the Add or Remove Connectors window, click on Next -> Workspace. The Redis connector should be available. Select it and click on OK. Then click on Finish.
+3. The Redis connector zip file should be now be present under the Connector Exporter project.
+
 ### Add integration logic
 
 First create an API, which will be where we configure the integration logic. Right click on the created Integration Project and select, **New** -> **Rest API** to create the REST API. Specify the API name as `SampleRdisAPI` and API context as `/resources`.


### PR DESCRIPTION
## Purpose
Without adding the Redis connector to the Connector Exporter project, the server will throw a runtime error saying unkown reference to the connector.

## Goals
Updated the document from Line 41 to 47 to mention the steps required for adding the Redis connector to the Connector Exporter project in Integration Studio. 

## Approach
Steps to add the Redis connector to the Connector Exporter project. This is needed to access the Redis connector and its operations at runtime.

1. Right click on the connector exporter project and click on New-> Add/Remove Connectors.
![image](https://user-images.githubusercontent.com/66669898/95089322-a5270a80-0741-11eb-88a7-5962aef4cb0e.png)

2. Then in the Add or Remove Connectors window, click on Next -> Workspace. The Redis connector should be available. Select it and click on OK. Then click on Finish.
![image](https://user-images.githubusercontent.com/66669898/95089439-c687f680-0741-11eb-8520-06df8667b55f.png)
![image](https://user-images.githubusercontent.com/66669898/95089499-d6073f80-0741-11eb-83e4-94d1f6f1561b.png)

3. The Redis connector zip file should be now be present under the Connector Exporter project.
![image](https://user-images.githubusercontent.com/66669898/95089557-e8817900-0741-11eb-880b-280afa4d8380.png)
