### PR TITLE
(7.1.0 branch) HL7 parameters and examples

### DIFF
--- a/en/micro-integrator/docs/references/mediators/property-reference/axis2-properties.md
+++ b/en/micro-integrator/docs/references/mediators/property-reference/axis2-properties.md
@@ -340,7 +340,7 @@ Axis2 properties allow you to configure the web services engine in WSO2 Micro In
 			Description
 		</td>
 		<td>
-			Use this property to specify whether an ACK or NACK should be returned to the messaging client as an acknowledgement. If you select a NACK response, you need to specify a custom NACK message by using the <code>HL7_NACK_MESSAGE</code> as given below.
+			Use this property to specify whether an ACK or NACK should be returned to the messaging client as an acknowledgement. If you select a NACK response, you have the option to specify a custom NACK message that should be sent to the client along with the NACK.
 		</td>
 	</tr>
 	<tr>

--- a/en/micro-integrator/docs/references/mediators/property-reference/axis2-properties.md
+++ b/en/micro-integrator/docs/references/mediators/property-reference/axis2-properties.md
@@ -3,7 +3,7 @@
 !!! Info
 	The following are Axis2 properties that can be used with the [Property mediator](../../../references/mediators/property-Mediator.md) and the [Property Group mediator](../../../references/mediators/property-Group-Mediator.md).
 
-Axis2 properties allow you to configure the web services engine in WSO2 Micro Integrator, such as specifying how to cache JMS objects, setting the minimum and maximum threads for consuming messages, and forcing outgoing HTTP/S messages to use HTTP 1.0. You can access some of these properties through the [Property mediator](../../../references/mediators/property-Mediator.md) with the scope set to `axis2` or `axis2-client` as shown below.
+Axis2 properties allow you to configure the web services engine in WSO2 Micro Integrator, such as specifying how to cache JMS objects, setting the minimum and maximum threads for consuming messages, and forcing outgoing HTTP/S messages to use HTTP 1.0. You can access some of these properties by using the [Property mediator](../../../references/mediators/property-Mediator.md) with the scope set to `axis2` or `axis2-client` as shown below.
 
 ## CacheLevel
 
@@ -238,3 +238,300 @@ Axis2 properties allow you to configure the web services engine in WSO2 Micro In
 | **Scope**            | axis2                                                                                                                                                                                      |
 | **Description**      | Specifies the encoding type used for the content of the files processed by the transport. Note that this property cannot be used if the 'setCharacterEncoding' property is set to 'false'. |
 | **Example**          | `             <property name="CHARACTER_SET_ENCODING" value="UTF-8" scope="axis2" type="STRING"/>            `                                                                             |
+
+## HL7 Properties
+
+### HL7_GENERATE_ACK
+
+<table>
+	<tr>
+		<th>
+			Parameter
+		</th>
+		<th>
+			Description
+		</th>
+	</tr>
+	<tr>
+		<td>
+			Name
+		</td>
+		<td>
+			HL7_GENERATE_ACK
+		</td>
+	</tr>
+	<tr>
+		<td>
+			Possible Values
+		</td>
+		<td>
+			true/false
+		</td>
+	</tr>
+	<tr>
+		<td>
+			Scope
+		</td>
+		<td>
+			axis2
+		</td>
+	</tr>
+	<tr>
+		<td>
+			Description
+		</td>
+		<td>
+			Use this property to disable auto acknowledgement of HL7 messages that are received by the Micro Integrator. By default, auto acknowledgement is enabled in the Micro Integrator. You can disable this by setting this property to 'false'.
+		</td>
+	</tr>
+	<tr>
+		<td>
+			Example
+		</td>
+		<td>
+			<div class="content-wrapper">
+			<div class="code panel pdl" style="border-width: 1px;">
+			<div class="codeContent panelContent pdl">
+			<div class="sourceCode" id="cb1" data-syntaxhighlighter-params="brush: xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: xml; gutter: false; theme: Confluence"><pre class="sourceCode xml"><code class="sourceCode xml"><span id="cb1-1"><a href="#cb1-1"></a><span class="kw">&lt;property</span><span class="ot"> name=</span><span class="st">&quot;HL7_GENERATE_ACK&quot;</span><span class="ot"> <span class="ot"> scope=</span><span class="st">&quot;axis2&quot;</span><span class="ot"> value=</span><span class="st">&quot;true&quot;</span><span class="kw">&lt;/parameter&gt;</span></span></code></pre></div>
+			</div>
+			</div>
+			</div>
+		</td>
+	</tr>
+</table>
+
+### HL7_RESULT_MODE
+
+<table>
+	<tr>
+		<th>
+			Parameter
+		</th>
+		<th>
+			Description
+		</th>
+	</tr>
+	<tr>
+		<td>
+			Name
+		</td>
+		<td>
+			HL7_RESULT_MODE
+		</td>
+	</tr>
+	<tr>
+		<td>
+			Possible Values
+		</td>
+		<td>
+			<code>ACK</code> or <code>NACK</code>
+		</td>
+	</tr>
+	<tr>
+		<td>
+			Scope
+		</td>
+		<td>
+			axis2
+		</td>
+	</tr>
+	<tr>
+		<td>
+			Description
+		</td>
+		<td>
+			Use this property to specify whether an ACK or NACK should be returned to the messaging client as an acknowledgement. If you select a NACK response, you need to specify a custom NACK message by using the <code>HL7_NACK_MESSAGE</code> as given below.
+		</td>
+	</tr>
+	<tr>
+		<td>
+			Example
+		</td>
+		<td>
+			<div class="content-wrapper">
+			<div class="code panel pdl" style="border-width: 1px;">
+			<div class="codeContent panelContent pdl">
+			<div class="sourceCode" id="cb1" data-syntaxhighlighter-params="brush: xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: xml; gutter: false; theme: Confluence"><pre class="sourceCode xml"><code class="sourceCode xml"><span id="cb1-1"><a href="#cb1-1"></a><span class="kw">&lt;property</span><span class="ot"> name=</span><span class="st">&quot;HL7_RESULT_MODE&quot;</span><span class="ot"> <span class="ot"> scope=</span><span class="st">&quot;axis2&quot;</span><span class="ot"> value=</span><span class="st">&quot;ACK|NACK&quot;</span><span class="kw">&lt;/parameter&gt;</span></span></code></pre></div>
+			</div>
+			</div>
+			</div>
+		</td>
+	</tr>
+</table>
+
+### HL7_NACK_MESSAGE
+
+<table>
+	<tr>
+		<th>
+			Parameter
+		</th>
+		<th>
+			Description
+		</th>
+	</tr>
+	<tr>
+		<td>
+			Name
+		</td>
+		<td>
+			HL7_NACK_MESSAGE
+		</td>
+	</tr>
+	<tr>
+		<td>
+			Possible Values
+		</td>
+		<td>
+			User defined string value.
+		</td>
+	</tr>
+	<tr>
+		<td>
+			Scope
+		</td>
+		<td>
+			axis2
+		</td>
+	</tr>
+	<tr>
+		<td>
+			Description
+		</td>
+		<td>
+			Use this property to set a custom NACK message that should be sent to the HL7 client as an acknowledgement. This property can be used only if the HL7 result mode is set to <code>NACK</code>.
+		</td>
+	</tr>
+	<tr>
+		<td>
+			Example
+		</td>
+		<td>
+			<div class="content-wrapper">
+			<div class="code panel pdl" style="border-width: 1px;">
+			<div class="codeContent panelContent pdl">
+			<div class="sourceCode" id="cb1" data-syntaxhighlighter-params="brush: xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: xml; gutter: false; theme: Confluence"><pre class="sourceCode xml"><code class="sourceCode xml"><span id="cb1-1"><a href="#cb1-1"></a><span class="kw">&lt;property</span><span class="ot"> name=</span><span class="st">&quot;HL7_NACK_MESSAGE&quot;</span><span class="ot"> <span class="ot"> scope=</span><span class="st">&quot;axis2&quot;</span><span class="ot"> value=</span><span class="st">&quot;error message&quot;</span><span class="kw">&lt;/parameter&gt;</span></span></code></pre></div>
+			</div>
+			</div>
+			</div>
+		</td>
+	</tr>
+</table>
+
+### HL7_APPLICATION_ACK
+
+<table>
+	<tr>
+		<th>
+			Parameter
+		</th>
+		<th>
+			Description
+		</th>
+	</tr>
+	<tr>
+		<td>
+			Name
+		</td>
+		<td>
+			HL7_APPLICATION_ACK
+		</td>
+	</tr>
+	<tr>
+		<td>
+			Possible Values
+		</td>
+		<td>
+			true/false
+		</td>
+	</tr>
+	<tr>
+		<td>
+			Scope
+		</td>
+		<td>
+			axis2
+		</td>
+	</tr>
+	<tr>
+		<td>
+			Description
+		</td>
+		<td>
+			Use this property to specify whether the Micro Integrator should wait for the backend to process the message before sending an acknowledgement (ACK or NACK message) back to the messaging client.
+		</td>
+	</tr>
+	<tr>
+		<td>
+			Example
+		</td>
+		<td>
+			<div class="content-wrapper">
+			<div class="code panel pdl" style="border-width: 1px;">
+			<div class="codeContent panelContent pdl">
+			<div class="sourceCode" id="cb1" data-syntaxhighlighter-params="brush: xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: xml; gutter: false; theme: Confluence"><pre class="sourceCode xml"><code class="sourceCode xml"><span id="cb1-1"><a href="#cb1-1"></a><span class="kw">&lt;property</span><span class="ot"> name=</span><span class="st">&quot;HL7_APPLICATION_ACK&quot;</span><span class="ot"> <span class="ot"> scope=</span><span class="st">&quot;axis2&quot;</span><span class="ot"> value=</span><span class="st">&quot;true|false&quot;</span><span class="kw">&lt;/parameter&gt;</span></span></code></pre></div>
+			</div>
+			</div>
+			</div>
+		</td>
+	</tr>
+</table>
+
+### HL7_RAW_MESSAGE
+
+<table>
+	<tr>
+		<th>
+			Parameter
+		</th>
+		<th>
+			Description
+		</th>
+	</tr>
+	<tr>
+		<td>
+			Name
+		</td>
+		<td>
+			HL7_RAW_MESSAGE
+		</td>
+	</tr>
+	<tr>
+		<td>
+			Possible Values
+		</td>
+		<td>
+			$axis2:HL7_RAW_MESSAGE
+		</td>
+	</tr>
+	<tr>
+		<td>
+			Scope
+		</td>
+		<td>
+			axis2
+		</td>
+	</tr>
+	<tr>
+		<td>
+			Description
+		</td>
+		<td>
+			Use this property to retrieve the original raw EDI format HL7 message in an InSequence.
+		</td>
+	</tr>
+	<tr>
+		<td>
+			Example
+		</td>
+		<td>
+			<div class="content-wrapper">
+			<div class="code panel pdl" style="border-width: 1px;">
+			<div class="codeContent panelContent pdl">
+			<div class="sourceCode" id="cb1" data-syntaxhighlighter-params="brush: xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: xml; gutter: false; theme: Confluence"><pre class="sourceCode xml"><code class="sourceCode xml"><span id="cb1-1"><a href="#cb1-1"></a><span class="kw">&lt;property</span><span class="ot"> name=</span><span class="st">&quot;HL7_RAW_MESSAGE&quot;</span><span class="ot"> <span class="ot"> scope=</span><span class="st">&quot;axis2&quot;</span><span class="ot"> value=</span><span class="st">&quot;$axis2:HL7_RAW_MESSAGE&quot;</span><span class="kw">&lt;/parameter&gt;</span></span></code></pre></div>
+			</div>
+			</div>
+			</div>
+		</td>
+	</tr>
+</table>

--- a/en/micro-integrator/docs/references/synapse-properties/transport-parameters/hl7-transport-parameters.md
+++ b/en/micro-integrator/docs/references/synapse-properties/transport-parameters/hl7-transport-parameters.md
@@ -200,3 +200,4 @@ See the following examples demonstrating HL7 use cases:
 - [Enabling HL7](../../../../setup/transport_configurations/configuring-transports/#configuring-the-hl7-transport)
 - [Mediating HL7 Messages](../../../../use-cases/examples/hl7-examples/HL7_proxy_service)
 - [Configuring Message Acknowledgement for HL7 Messages](../../../../use-cases/examples/hl7-examples/acknowledge_hl7_messages)
+- [Using HL7 Messages with File Systems](../../../../use-cases/examples/hl7-examples/file_transfer_using_hl7)

--- a/en/micro-integrator/docs/references/synapse-properties/transport-parameters/hl7-transport-parameters.md
+++ b/en/micro-integrator/docs/references/synapse-properties/transport-parameters/hl7-transport-parameters.md
@@ -1,8 +1,5 @@
 # HL7 Parameters
 
-!!! Warning
-    This content is currently Work in Progress!
-
 When you implement an integration use case that handles HL7 messsages, you can use the following HL7 parameters in your [proxy service](../../../../develop/creating-artifacts/creating-a-proxy-service) artifact.
 
 !!! Info
@@ -12,74 +9,115 @@ When you implement an integration use case that handles HL7 messsages, you can u
 
 See [Creating a Proxy Service](../../../../develop/creating-artifacts/creating-a-proxy-service) for instructions.
 
-## Conformance profile
+## Service-level Parameters
 
-Add the parameter "transport.hl7.ConformanceProfilePath" in the proxy service to point to a URL where the HL7 conformance profile (XML file) can be found.
+### HL7 receiver port (Required)
 
-## Message pre-processing
+<table>
+  <tr>
+    <th>
+      Parameter
+    </th>
+    <th>
+      Description
+    </th>
+  </tr>
+  <tr>
+    <td>
+      transport.hl7.Port
+    </td>
+    <td>
+      Add this parameter to specify the port on which the Micro Integrator listens to incoming HL7 messages.
+    </td>
+  </tr>
+</table>
 
-Add the "transport.hl7.MessagePreprocessorClass" parameter in the proxy service to point to an implementation class of the interface "org.wso2.micro.integrator.business.messaging.hl7.common.HL7MessagePreprocessor", which is used to process raw HL7 messages before parsing them so that potential errors in the messages can be rectified using the transport.
+### HL7 Conformance profile path
 
-## Acknowledgement
+<table>
+  <tr>
+    <th>
+      Parameter
+    </th>
+    <th>
+      Description
+    </th>
+  </tr>
+  <tr>
+    <td>
+      transport.hl7.ConformanceProfilePath
+    </td>
+    <td>
+      Add this parameter to the proxy service to specify the URL of the HL7 conformance profile (XML file).
+    </td>
+  </tr>
+</table>
 
-You can enable or disable automatic message acknowledgment. When automatic message acknowledgment is enabled, an ACK is immediately sent back to the client after receiving a message. When it is disabled, the user is given control to send back an ACK/NACK message from an integration sequence after any message validations or related tasks.
+### Message acknowledgement
 
-When using a transport such as HTTP, to create an ACK/NACK message from an HL7 message in the flow, specify an axis2 scope message context property "HL7_GENERATE_ACK" and set its value to true. This ensures that an ACK/NACK message is created automatically when a message is sent (using the HL7 formatter). By default, an ACK message is created. If a NACK message is required instead, use the message context properties "HL7_RESULT_MODE" and "HL7_NACK_MESSAGE" as described below.
+<table>
+  <tr>
+    <th>
+      Parameter
+    </th>
+    <th>
+      Description
+    </th>
+  </tr>
+  <tr>
+    <td>
+      transport.hl7.AutoAck
+    </td>
+    <td>
+      Add this parameter to the proxy service to disable auto acknowledgement of HL7 messages. You can disable auto acknowledgement by setting this parameter to 'false'.</br></br>
+      By default, auto acknowledgement is enabled in the Micro Integrator, which means that an ACK message is sent to the client as soon as the message is received by the mediation sequence.</br></br>
+      <b>Note</b>: When automatic acknowledgment is disabled, you can manually configure ACK/NACK messages for HL7 in the mediation sequence by using the following mediation properties:
+      <ul>
+      	<li>
+      		<a href="../../../../references/mediators/property-reference/axis2-properties/#hl7_generate_ack">HL7_GENERATE_ACK</a>
+      	</li>
+      	<li>
+      		<a href="../../../../references/mediators/property-reference/axis2-properties/#hl7_result_mode">HL7_RESULT_MODE</a>
+      	</li>
+      	<li>
+      		<a href="../../../../references/mediators/property-reference/axis2-properties/#hl7_nack_message">HL7_NACK_MESSAGE</a>
+      	</li>
+      	<li>
+      		<a href="../../../../references/mediators/property-reference/axis2-properties/#hl7_application_ack">HL7_APPLICATION_ACK</a>
+      	</li>
+      	<li>
+      		<a href="../../../../references/mediators/property-reference/axis2-properties/#hl7_raw_message">HL7_RAW_MESSAGE</a>
+      	</li>
+      </ul> 
+      See <a href="../../../../use-cases/examples/hl7-examples/acknowledge_hl7_messages">Message Acknowledgement for HL7 Messages</a> for details.
+    </td>
+  </tr>
+</table>
 
-In the proxy service, add the following parameters to enable or disable auto-acknowledgement and validation:
+### Message pre-processing
 
-```xml
-<proxy>...
-   <parameter name="transport.hl7.AutoAck">true|false</parameter> <!-- default is true -->
-</proxy>
-```
+<table>
+  <tr>
+    <th>
+      Parameter
+    </th>
+    <th>
+      Description
+    </th>
+  </tr>
+  <tr>
+    <td>
+      transport.hl7.MessagePreprocessorClass
+    </td>
+    <td>
+      Add this parameter to the proxy service to specify an implementation class of the <code>org.wso2.micro.integrator.business.messaging.hl7.common.HL7MessagePreprocessor</code> interface. This will be used for processing raw HL7 messages before parsing them. This allows potential errors in the messages to be rectified using the transport.
+    </td>
+  </tr>
+</table>
 
-When ‘AutoAck’ is false, you can set the following properties inside an integration sequence.
-
-```xml
-<property name="HL7_RESULT_MODE" value="ACK|NACK" scope="axis2" /> <!-- notice the properties should be in axis2 scope -->
-```
-
-When the result mode is ‘NACK’, you can use the following property to provide a custom description of the error message.
-
-```xml
-<property name="HL7_NACK_MESSAGE" value="<ERROR MESSAGE>" scope="axis2" />
-```
-
-You can use the property "HL7_RAW_MESSAGE" in the axis2 scope to retrieve the original raw EDI format HL7 message in an in sequence. The user doesn't have to convert from XML to EDI again, so this usage may be particularly helpful inside a custom mediator.
-
-To control the encoding type of incoming messages, set the Java system property "ca.uhn.hl7v2.llp.charset".
-
-## Configuring application acknowledgement
-
-In general, we don't wait for the back-end application's response before sending an "accept-acknowledgement" message to the client. If you do want to wait for the application's response before sending the message, define the following property in the InSequence:
-
-```xml
-<property name="HL7_APPLICATION_ACK" value="true" scope="axis2"/> 
-```
-
-In this case, the request thread will wait until the back-end application returns the response before sending the "accept-acknowledgement" message to the client. You can configure how long request threads wait for the application's response by configuring the time-out in milliseconds at the transport level:
-
-```toml
-[[custom_transport.listener]]
-class="org.wso2.micro.integrator.business.messaging.hl7.transport.HL7TransportListener"
-protocol = "hl7"
-parameter.'transport.hl7.TimeOut' = 1000
-```
-
-For more information on configuring the proxy service for application acknowledgment, see Application acknowledgement in Creating an HL7 Proxy Service.
-
-## Validating messages
+### Message validation
 
 By default, the HL7 transport validates messages before building their XML representation. You configure validation with the following parameter in the proxy service:
-
-```xml
-<proxy>...
-   <parameter name="transport.hl7.ValidateMessage">true|false</parameter> <!-- default is true -->
-</proxy>
-```
-
-When transport.hl7.ValidateMessage is set to false, you can set the following parameters to handle invalid messages:
 
 <table>
    <tr>
@@ -91,11 +129,19 @@ When transport.hl7.ValidateMessage is set to false, you can set the following pa
       </th>
    </tr>
    <tr>
+     <td>
+       transport.hl7.ValidateMessage
+     </td>
+     <td>
+       By default, the HL7 transport validates messages before building their XML representation. You can set this parameter to false if you want to disable message validation.
+     </td>
+   </tr>
+   <tr>
       <td>
          transport.hl7.BuildInvalidMessages
       </td>
       <td>
-         When set to true, builds a SOAP envelope with the contents of the raw HL7 message inside the <rawMessage> element.
+         When transport.hl7.ValidateMessage is set to false, you can set this parameter to handle invalid messages.</br></br> When this parameter is set to true, builds a SOAP envelope with the contents of the raw HL7 message inside the element.
       </td>
    </tr>
    <tr>
@@ -103,12 +149,12 @@ When transport.hl7.ValidateMessage is set to false, you can set the following pa
          transport.hl7.PassThroughInvalidMessages
       </td>
       <td>
-         When BuildInvalidMessages is set to true, you use this parameter to specify whether to pass this message through (true) or to throw a fault (false).
+         When transport.hl7.ValidateMessage is set to false, you can set this parameter to handle invalid messages.</br></br> When this parameter (BuildInvalidMessages) is set to true, you use this parameter to specify whether to pass this message through (true) or to throw a fault (false).
       </td>
    </tr>
 </table>
 
-## Configuring the thread pool
+### Thread pool configurations
 
 The HL7 transport uses a thread pool to manage connections. A larger thread pool provides greater performance, because the transport can process more messages simultaneously, but it also uses more memory. You can add the following properties to the proxy service to configure the thread pool to suit your environment:
 
@@ -147,156 +193,10 @@ The HL7 transport uses a thread pool to manage connections. A larger thread pool
    </tr>
 </table>
 
-## Creating an HL7 Proxy Service
+## Related topics
 
-You can create a proxy service that uses the HL7 transport, to connect to an HL7 server. This proxy service will receive HL7-client connections and send them to the HL7 server. It can also receive XML messages over HTTP/HTTPS and transform them into HL7 before sending them to the server, and it will transform the HL7 responses back into XML.
+See the following examples demonstrating HL7 use cases:
 
-!!! Info
-    If you want to try the example configurations on this page, you must have an HL7 client and HL7 back-end 
-    application set up and running. To see a sample that illustrates how to create an HL7 client and back-end 
-    application, see: [WSO2 Hl7 Samples](https://github.com/wso2/carbon-mediation/tree/v4.7.61/components/business-adaptors/hl7/org.wso2.carbon.business.messaging.hl7.samples/src/main/java/org/wso2/carbon/business/messaging/hl7/samples)
-```xml
-<proxy xmlns="http://ws.apache.org/ns/synapse" name="hl7testproxy" transports="https,http,hl7" statistics="disable" trace="disable" startOnLoad="true">
- <target>
-    <inSequence>
-       <log level="full" />
-    </inSequence>
-    <outSequence>
-       <log level="full" />
-       <send />
-    </outSequence>
-    <endpoint name="hl7_endpoint">
-       <address uri="hl7://localhost:9988" />
-    </endpoint>
- </target>
- <parameter name="transport.hl7.Port">9292</parameter>
-</proxy>
-```
-
-For information on additional configuration you can set on the HL7 transport, see HL7 Transport.
-
-## Using the HL7 Message Store
-
-You can use the HL7 message store to automatically store HL7 messages, allowing you to audit and replay messages as needed. The HL7 store is a custom message store implementation on top of Open JPA. To use the message store, you take the following steps:
-
-```xml tab='Proxy Service'
-<proxy name="HL7Store" startOnLoad="true" trace="disable" transports=”hl7”>
-   <description/>
-   <target>
-      <inSequence>
-         <property name="HL7_RESULT_MODE" value="ACK" scope="axis2"/>
-         <log level="full"/>
-         <property name="messageType" value="application/edi-hl7" scope="axis2"/>
-         <clone>
-            <target sequence="StoreSequence"/>
-            <target sequence="SendSequence"/>
-         </clone>
-      </inSequence>
-   </target>
-   <parameter name="transport.hl7.AutoAck">false</parameter>
-   <parameter name="transport.hl7.Port">55557</parameter>
-   <parameter name="transport.hl7.ValidateMessage">false</parameter>
-</proxy>
-```
-
-```xml tab='Store Sequence'
-<sequence name="StoreSequence">
-   <property name="OUT_ONLY" value="true"/>
-   <store messageStore="HL7StoreJPA"/>
-</sequence>
-```
-
-```xml tab='Send Sequence'
-<sequence name="SendSequence">
-    <call>
-        <endpoint>
-            <address uri="hl7://localhost:9988">
-                <suspendOnFailure>
-                    <initialDuration>-1</initialDuration>
-                    <progressionFactor>1</progressionFactor>
-                </suspendOnFailure>
-                <markForSuspension>
-                    <retriesBeforeSuspension>0</retriesBeforeSuspension>
-                </markForSuspension>
-            </address>
-        </endpoint>
-    </call>
-    <log level="full"/>
-    <drop/>
-</sequence>
-```
-
-```xml tab='Message Store'
-<messageStore class="org.wso2.micro.integrator.business.messaging.hl7.store.jpa.JPAStore"
-                 name="HL7StoreJPA">
-   <parameter name="openjpa.ConnectionDriverName">org.apache.commons.dbcp.BasicDataSource</parameter>
-   <parameter name="openjpa.ConnectionProperties">DriverClassName=com.mysql.jdbc.Driver, Url=jdbc:mysql://localhost/hl7storejpa,  MaxActive=100,  MaxWait=10000,  TestOnBorrow=true,  Username=root,  Password=root</parameter>
-   <parameter name="openjpa.jdbc.DBDictionary">blobTypeName=LONGBLOB</parameter>
-</messageStore>
-```
-
-In this configuration, when the HL7 proxy service runs, an HL7 service will start listening on the port defined in the transport.hl7.Port service parameter. When an HL7 message arrives, the proxy will send an ACK back to the client as specified in the HL7_RESULT_MODE property. The Clone mediator is used inside the proxy to replicate the message into the Send and Store sequences, where the message is sent to the specified endpoint and is also stored in the message store HL7StoreJPA.
-
-The HL7StoreJPA message store is a custom message store implemented in org.wso2.micro.integrator.business.messaging.hl7.store.jpa.JPAStore. It takes OpenJPA properties as parameters. In this example, the openjpa.ConnectionProperties and openjpa.ConnectionDriverName properties are used to create an Apache DBCP pooled connection set to a MySQL database. You will need to create the database specified in the connection properties and provide the database authentication details matching your database. You may also need to place the JDBC drivers for your database into <EI_HOME>/lib . 
-
-You can view the messages in this message store using the HL7 Console UI. You can search for messages on the unique message UUID or HL7 specific Control ID. The search field supports the wildcard ‘%’ to allow LIKE queries. The table can also be filtered to search for content within messages.
-
-Selected messages can be edited and injected into a proxy service. Reinjecting a message to the same service will result in a new message being stored with a different message UUID.
-
-## Accept acknowledgement
-
-If user doesn't want to wait for the back-end service to process the message and only needs acknowledgment from the system that the message was received, you can configure the proxy service to send an ACK/NACK message after the message is received. For example:
-
-```xml
-<proxy name="HL7Proxy" transports="hl7" startOnLoad="true" trace="disable">
-    <description/>
-    <target>
-        <inSequence>
-            <property name="HL7_RESULT_MODE" value="ACK" scope="axis2"/>
-            <property name="HL7_GENERATE_ACK" value="true" scope="axis2"/>
-            <send>
-               <endpoint name="hl7_endpoint">
-                    <address uri="hl7://localhost:9988"/>
-                </endpoint>
-            </send>
-        </inSequence>
-        <outSequence>
-            <log level="custom">
-                <property name="OUT" value="***********out sequence proxy2***********"/>
-            </log>
-           <drop/>
-        </outSequence>
-     </target>
-     <parameter name="transport.hl7.AutoAck">false</parameter>
-     <parameter name="transport.hl7.ValidateMessage">false</parameter>
-     <parameter name="transport.hl7.Port">9293</parameter>
-</proxy>
-```
-
-## Application acknowledgement
-
-If you want to wait for the application's response before sending the acknowledgment message (see Configuring application acknowledgement), you add the HL7_APPLICATION_ACK property to the inSequence and any additional HL7 properties and transport parameters as needed. For example:
-
-```xml
-<proxy xmlns="http://ws.apache.org/ns/synapse" name="HL7Proxy" transports="hl7" statistics="disable" trace="disable" startOnLoad="true">
-  <target>
-      <inSequence>
-           <property name="HL7_APPLICATION_ACK" value="true" scope="axis2"/> 
-            <send>
-                  <endpoint name="endpoint_urn_uuid_9CB8D06C91A1E996796270828144799-1418795938">
-                          <address uri="hl7://localhost:9988"/>
-                   </endpoint>
-             </send>
-      </inSequence>
-      <outSequence> 
-           <property name="HL7_RESULT_MODE" value="NACK" scope="axis2"/>
-           <property name="HL7_NACK_MESSAGE" value="error msg" scope="axis2"/>
-           <send/>
-      </outSequence>
-  </target>
-  <parameter name="transport.hl7.AutoAck">false</parameter>
-  <parameter name="transport.hl7.ValidateMessage">true</parameter>
-  <parameter name="transport.hl7.Port">9294</parameter>
-  <description></description>
-</proxy>
-```
+- [Enabling HL7](../../../../setup/transport_configurations/configuring-transports/#configuring-the-hl7-transport)
+- [Mediating HL7 Messages](../../../../use-cases/examples/hl7-examples/HL7_proxy_service)
+- [Configuring Message Acknowledgement for HL7 Messages](../../../../use-cases/examples/hl7-examples/acknowledge_hl7_messages)

--- a/en/micro-integrator/docs/setup/transport_configurations/configuring-transports.md
+++ b/en/micro-integrator/docs/setup/transport_configurations/configuring-transports.md
@@ -126,13 +126,13 @@ HL7 is not shipped by default in the pack. To make the transport available, down
 
 ### Enabling the transport
 
-Add the following configurations to the `deployment.toml` file (stored in the `<MI_HOME>/conf` folder) to enable it. 
+Add the following configurations to the `deployment.toml` file (stored in the `<MI_HOME>/conf` folder: 
 
 ```toml tab='HL7 Listener'
 [[custom_transport.listener]]
 class="org.wso2.micro.integrator.business.messaging.hl7.transport.HL7TransportListener"
 protocol = "hl7"
-parameter.'transport.hl7.TimeOut' = 1000
+parameter.'transport.hl7.TimeOut' = 10000
 ```
 
 ```toml tab='HL7 Sender'
@@ -140,6 +140,8 @@ parameter.'transport.hl7.TimeOut' = 1000
 class="org.wso2.micro.integrator.business.messaging.hl7.transport.HL7TransportSender"
 protocol = "hl7"
 ```
+
+You can configure how long request threads wait for the application's response by specifying the `parameter.'transport.hl7.TimeOut'` parameter as shown above. This configures the timeout in milliseconds at the transport level.
 
 ## Configuring the TCP transport
 

--- a/en/micro-integrator/docs/use-cases/examples/hl7-examples/HL7_proxy_service.md
+++ b/en/micro-integrator/docs/use-cases/examples/hl7-examples/HL7_proxy_service.md
@@ -1,0 +1,42 @@
+# Mediating HL7 Messages
+
+You can create a proxy service that uses the HL7 transport to connect to an HL7 server. This proxy service will receive HL7-client connections and send them to the HL7 server. It can also receive XML messages over HTTP/HTTPS and transform them into HL7 before sending them to the server, and it will transform the HL7 responses back into XML.
+
+## Synapse configuration
+
+Given below is an example proxy that receives HL7 messages from a client and relays the message to an HL7 server. See the instructions on how to [build and run](#build-and-run) this example.
+
+```xml
+<proxy xmlns="http://ws.apache.org/ns/synapse" name="hl7testproxy" transports="https,http,hl7" statistics="disable" trace="disable" startOnLoad="true">
+ <target>
+    <inSequence>
+       <log level="full" />
+    </inSequence>
+    <outSequence>
+       <log level="full" />
+       <send />
+    </outSequence>
+    <endpoint name="hl7_endpoint">
+       <address uri="hl7://localhost:9988" />
+    </endpoint>
+ </target>
+ <parameter name="transport.hl7.Port">9292</parameter>
+</proxy>
+```
+
+## Build and run
+
+Create the artifacts:
+
+1. [Set up WSO2 Integration Studio](../../../../develop/installing-WSO2-Integration-Studio).
+2. [Create an integration project](../../../../develop/create-integration-project) with an <b>ESB Configs</b> module and an <b>Composite Exporter</b>.
+3. [Create the proxy service](../../../../develop/creating-artifacts/creating-a-proxy-service) with the configurations given above.
+4. [Configure the HL7 transport](../../../../setup/transport_configurations/configuring-transports/#configuring-the-hl7-transport) in your Micro Integrator.
+5. [Deploy the artifacts](../../../../develop/deploy-artifacts) in your Micro Integrator.
+
+To test this scenario, you need the following:
+
+- An HL7 client that sends messages to the port specified by the `transport.hl7.Port` parameter.
+- An HL7 back-end application that recieves messages from the Micro Integrator.
+
+You can simulate the HL7 client and back-end application using a tool such as <b>HAPI</b>.

--- a/en/micro-integrator/docs/use-cases/examples/hl7-examples/acknowledge_hl7_messages.md
+++ b/en/micro-integrator/docs/use-cases/examples/hl7-examples/acknowledge_hl7_messages.md
@@ -2,7 +2,7 @@
 
 Automatic message acknowledgement for HL7 messages is enabled in the Micro Integrator by default. With this setting, an ACK is immediately returned to the client when a message is received. 
 
-If required, you can disable automatic acknowledgement. This allows you to control how and when ACK/NACK messages should be returned to the client. Tha is, you can define the integration logic to generate an ack/nack message after message validations or related tasks.
+If required, you can disable automatic acknowledgement. This allows you to control how and when ACK/NACK messages should be returned to the client. That is, you can define the integration logic to generate an ack/nack message after message validations or related tasks.
 
 ## Configuring message acknowldegement for HL7
 

--- a/en/micro-integrator/docs/use-cases/examples/hl7-examples/acknowledge_hl7_messages.md
+++ b/en/micro-integrator/docs/use-cases/examples/hl7-examples/acknowledge_hl7_messages.md
@@ -1,0 +1,151 @@
+# Acknowledging HL7 Messages
+
+Automatic message acknowledgement for HL7 messages is enabled in the Micro Integrator by default. With this setting, an ACK is immediately returned to the client when a message is received. 
+
+If required, you can disable automatic acknowledgement. This allows you to control how and when ACK/NACK messages should be returned to the client. Tha is, you can define the integration logic to generate an ack/nack message after message validations or related tasks.
+
+## Configuring message acknowldegement for HL7
+
+When auto acknowledgement for HL7 messages is disabled in the Micro Integrator, you can manually configure ACK/NACK messages in the mediation logic by using the Property mediator. 
+
+!!! Info
+    Add the following parameter to the proxy service to disable auto acknowledgement and validation:
+    ```xml
+    <parameter name="transport.hl7.AutoAck">false</parameter>
+    ```
+
+- Specify an axis2 scope message context property `HL7_GENERATE_ACK` and set its value to true as shown below.
+
+    ```xml
+    <property name="HL7_GENERATE_ACK" value="true" scope="axis2"/>
+    ```
+
+    This ensures that an ACK/NACK message is created automatically when a message is sent (using the HL7 formatter). By default, an ACK message is created.
+
+- If a NACK message is required instead, set the result mode to `NACK` and provide a custom NACK message as shown below. 
+
+    ```xml tab='HL7 Result Mode'
+    <property name="HL7_RESULT_MODE" value="NACK" scope="axis2" />
+    ```
+
+    ```xml tab='NACK Message'
+    <property name="HL7_NACK_MESSAGE" value="ERROR MESSAGE" scope="axis2" />
+    ```
+
+- You can use the `HL7_RAW_MESSAGE` property in the axis2 scope to retrieve the original raw EDI format HL7 message in an InSequence. The user doesn't have to convert from XML to EDI again. Therefore, this may be particularly helpful inside a custom mediator.
+
+    ```xml
+    <property name="HL7_RAW_MESSAGE" value="$axis2:HL7_RAW_MESSAGE" scope="axis2" />
+    ```
+
+- To control the encoding type of incoming messages, set the Java system property `ca.uhn.hl7v2.llp.charset`.
+
+- If you do want to wait for the back-end application's response before sending the ACK/NACK message to the client, define the following property in the InSequence:
+
+    ```xml
+    <property name="HL7_APPLICATION_ACK" value="true" scope="axis2"/> 
+    ```
+
+    In this case, the request thread will wait until the back-end application returns the response before sending the "accept-acknowledgement" message to the client. 
+
+## Example 1: Generate ACK/NACK before the backend responds
+
+Consider an example where the client sending the message only requires an acknowledgement from the proxy service that the message was received. It does not need to wait for the back-end service to process the message before receiving this acknowledgement.
+
+### Synapse configuration
+
+Given below is a sample proxy service that is configured to send an ACK/NACK as soon as the message is received. 
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<proxy xmlns="http://ws.apache.org/ns/synapse" name="HL7Proxy" transports="hl7" startOnLoad="true" trace="disable">
+    <description/>
+    <target>
+        <inSequence>
+            <property name="HL7_RESULT_MODE" value="ACK" scope="axis2"/>
+            <property name="HL7_GENERATE_ACK" value="true" scope="axis2"/>
+            <send>
+               <endpoint name="hl7_endpoint">
+                    <address uri="hl7://localhost:9988"/>
+                </endpoint>
+            </send>
+        </inSequence>
+        <outSequence>
+            <log level="custom">
+                <property name="OUT" value="***********out sequence proxy2***********"/>
+            </log>
+           <drop/>
+        </outSequence>
+     </target>
+     <parameter name="transport.hl7.AutoAck">false</parameter>
+     <parameter name="transport.hl7.ValidateMessage">false</parameter>
+     <parameter name="transport.hl7.Port">9293</parameter>
+</proxy>
+```
+
+### Build and run
+
+Create the artifacts:
+
+1. [Set up WSO2 Integration Studio](../../../../develop/installing-WSO2-Integration-Studio).
+2. [Create an integration project](../../../../develop/create-integration-project) with an <b>ESB Configs</b> module and an <b>Composite Exporter</b>.
+3. [Create the proxy service](../../../../develop/creating-artifacts/creating-a-proxy-service) with the configurations given above.
+4. [Configure the HL7 transport](../../../../setup/transport_configurations/configuring-transports/#configuring-the-hl7-transport) in your Micro Integrator.
+5. [Deploy the artifacts](../../../../develop/deploy-artifacts) in your Micro Integrator.
+
+To test this scenario, you need the following:
+
+- An HL7 client that sends messages to the port specified by the `transport.hl7.Port` parameter.
+- An HL7 back-end application that recieves messages from the Micro Integrator.
+
+You can simulate the HL7 client and back-end application using a tool such as <b>HAPI</b>.
+
+## Example 2: Generate ACK/NACK after the backend responds
+
+Consider an example where the client sending the message requires an acknowledgement from the proxy service only after the back-end service has processed the message.
+
+### Synapse configuration
+
+The following proxy service is configured to send a NACK message after the backend has processed the message.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<proxy xmlns="http://ws.apache.org/ns/synapse" name="HL7Proxy" transports="hl7" statistics="disable" trace="disable" startOnLoad="true">
+  <target>
+      <inSequence>
+           <property name="HL7_APPLICATION_ACK" value="true" scope="axis2"/> 
+            <send>
+                  <endpoint name="endpoint_urn_uuid_9CB8D06C91A1E996796270828144799-1418795938">
+                          <address uri="hl7://localhost:9988"/>
+                  </endpoint>
+            </send>
+      </inSequence>
+      <outSequence> 
+           <property name="HL7_RESULT_MODE" value="NACK" scope="axis2"/>
+           <property name="HL7_NACK_MESSAGE" value="error msg" scope="axis2"/>
+           <send/>
+      </outSequence>
+  </target>
+  <parameter name="transport.hl7.AutoAck">false</parameter>
+  <parameter name="transport.hl7.ValidateMessage">true</parameter>
+  <parameter name="transport.hl7.Port">9294</parameter>
+  <description></description>
+</proxy>
+```
+
+### Build and run
+
+Create the artifacts:
+
+1. [Set up WSO2 Integration Studio](../../../../develop/installing-WSO2-Integration-Studio).
+2. [Create an integration project](../../../../develop/create-integration-project) with an <b>ESB Configs</b> module and an <b>Composite Exporter</b>.
+3. [Create the proxy service](../../../../develop/creating-artifacts/creating-a-proxy-service) with the configurations given above.
+4. [Configure the HL7 transport](../../../../setup/transport_configurations/configuring-transports/#configuring-the-hl7-transport) in your Micro Integrator.
+5. [Deploy the artifacts](../../../../develop/deploy-artifacts) in your Micro Integrator.
+
+To test this scenario, you need the following:
+
+- An HL7 client that sends messages to the port specified by the `transport.hl7.Port` parameter.
+- An HL7 back-end application that recieves messages from the Micro Integrator.
+
+You can simulate the HL7 client and back-end application using a tool such as <b>HAPI</b>.

--- a/en/micro-integrator/docs/use-cases/examples/hl7-examples/file_transfer_using_hl7.md
+++ b/en/micro-integrator/docs/use-cases/examples/hl7-examples/file_transfer_using_hl7.md
@@ -1,0 +1,177 @@
+# Using HL7 Messages with File Systems
+
+The Micro Integrator of WSO2 EI allows messages to be transferred between HL7 and the file system using the HL7 
+and VFS transports.
+
+## Transferring HL7 messages between file systems
+
+Let's look at how a proxy service reads HL7 messages stored in a file system and transfers them to another file system.
+
+### Synapse configuration
+
+Given below is a proxy service that is configured to detect HL7 files (`.hl7`) in the folder specified by the `transport.vfs.FileURI` parameter. Note that the VFS content type is set to `application/edi-hl7` MIME type with an optional charset encoding. When you save the .hl7 file to the `home/user/test/in` folder, the proxy service invokes the HL7 builders/formatters and builds the HL7 message into its equivalent XML format. It then forwards the message to the VFS endpoint `/tmp/out`.
+
+!!! Info
+    Be sure to replace file directories specied below with actual directories in your own file system.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<proxy xmlns="http://ws.apache.org/ns/synapse" name="FileSystemToFileSystem" transports="vfs">
+  <target>
+    <inSequence>
+      <property name="OUT_ONLY" value="true" scope="default" type="STRING"/>
+      <property name="transport.vfs.ReplyFileName" expression="get-property('transport','FILE_NAME')" scope="transport" type="STRING"/>
+      <log level="full"/>
+      <send>
+        <endpoint>
+          <address uri="vfs:file:///home/user/test/out"/>
+        </endpoint>
+      </send>
+    </inSequence>
+  </target>
+  <parameter name="transport.PollInterval">5</parameter>
+  <parameter name="transport.vfs.FileURI">file:///home/user/test/in</parameter>
+  <parameter name="transport.vfs.FileNamePattern">.*\.hl7</parameter>
+  <parameter name="transport.vfs.ContentType">application/edi-hl7;charset="iso-8859-15"</parameter>
+  <parameter name="transport.hl7.ValidateMessage">false</parameter>
+</proxy>
+```
+
+### Build and run
+
+Create the artifacts:
+
+1. [Set up WSO2 Integration Studio](../../../../develop/installing-WSO2-Integration-Studio).
+2. [Create an integration project](../../../../develop/create-integration-project) with an <b>ESB Configs</b> module and an <b>Composite Exporter</b>.
+3. [Create the proxy service](../../../../develop/creating-artifacts/creating-a-proxy-service) with the configurations given above.
+4. [Configure the HL7 transport](../../../../setup/transport_configurations/configuring-transports/#configuring-the-hl7-transport) in your Micro Integrator.
+5. [Deploy the artifacts](../../../../develop/deploy-artifacts) in your Micro Integrator.
+
+To test this scenario:
+
+1.	Copy the following HL7 message into a text editor and save it with the `.hl7` extension inside the directory you specified with the `transport.vfs.FileURI` parameter in the above example.
+
+	```bash
+	MSH|^~\&|Abc|Def|Ghi|JKL|20131231000000||ADT^A01|1234567|P|2.6|||NE|NE|CH|
+	```
+	
+2.	See that the files are immediately moved to the folder specified by the endpoint.
+
+## Transferring messages from HL7 to file system
+
+Now, let's look at how we can receive an HL7 message and transfer it to a file system. 
+
+### Synapse configuration
+
+When the following proxy service runs, an HL7 service will start listening on the port defined by the `transport.hl7.Port` parameter. When the HL7 message arrives, the proxy will send an ACK back to the client as specified in the `HL7_RESULT_MODE` property. The HL7 message is then processed and sent to the VFS endpoint, which will save the HL7 message to the given directory.
+
+!!! Info
+    Be sure to replace file directories specied below with actual directories in your own file system. 
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<proxy xmlns="http://ws.apache.org/ns/synapse"
+     name="HL7ToFileSystem"
+     transports="hl7"
+     statistics="disable"
+     trace="disable"
+     startOnLoad="true">
+ <target>
+    <inSequence>
+       <log level="full"/>
+       <property name="HL7_RESULT_MODE" value="ACK" scope="axis2"/>
+       <property name="OUT_ONLY" value="true"/>
+       <property name="transport.vfs.ReplyFileName"
+                 expression="fn:concat(get-property('SYSTEM_DATE', 'yyyyMMdd.HHmmssSSS'), '.xml')"
+                 scope="transport"/>
+       <send>
+          <endpoint>
+             <address uri="vfs:file:///home/user/test/out"/>
+          </endpoint>
+       </send>
+    </inSequence>
+ </target>
+ <parameter name="transport.hl7.AutoAck">false</parameter>
+ <parameter name="transport.hl7.Port">55555</parameter>
+ <parameter name="transport.hl7.ValidateMessage">false</parameter>
+ <description/>
+</proxy>
+```
+
+### Build and run
+
+Create the artifacts:
+
+1. [Set up WSO2 Integration Studio](../../../../develop/installing-WSO2-Integration-Studio).
+2. [Create an integration project](../../../../develop/create-integration-project) with an <b>ESB Configs</b> module and an <b>Composite Exporter</b>.
+3. [Create the proxy service](../../../../develop/creating-artifacts/creating-a-proxy-service) with the configurations given above.
+4. [Configure the HL7 transport](../../../../setup/transport_configurations/configuring-transports/#configuring-the-hl7-transport) in your Micro Integrator.
+5. [Deploy the artifacts](../../../../develop/deploy-artifacts) in your Micro Integrator.
+
+To test this scenario: 
+
+1.	Use an HL7 client (such as <b>HAPI</b>) to send a message to the port specified by the `transport.hl7.Port` parameter. 
+2.	See that the message is successfully saved to the file system specified as the endpoint.
+
+## Transferring messages from HL7 to FTP
+
+The following configuration is similar to the previous example, but it illustrates how to process files between an HL7 endpoint and files accessed through FTP.
+
+### Synapse configuration
+
+Given below is a proxy service that will detect .hl7 files in the `transport.vfs.FileURI` directory and send them to the HL7 endpoint.
+
+!!! Info
+    Be sure to replace file directories specied below with actual directories in your own file system.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<proxy xmlns="http://ws.apache.org/ns/synapse"
+       name="SFTPToHL7"
+       transports="vfs"
+       statistics="disable"
+       trace="disable"
+       startOnLoad="true">
+   <target>
+      <inSequence>
+         <property name="OUT_ONLY" value="true" scope="default" type="STRING"/>
+         <log level="full"/>
+         <send>
+            <endpoint>
+               <address uri="hl7://localhost:9988"/>
+            </endpoint>
+         </send>
+      </inSequence>
+      <outSequence>
+         <drop/>
+      </outSequence>
+   </target>
+   <parameter name="transport.vfs.ReconnectTimeout">2</parameter>
+   <parameter name="transport.vfs.ActionAfterProcess">MOVE</parameter>
+   <parameter name="transport.PollInterval">5</parameter>
+   <parameter name="transport.hl7.AutoAck">false</parameter>
+   <parameter name="transport.vfs.MoveAfterProcess">vfs:sftp://user:pass@localhost/vfs/out</parameter>
+   <parameter name="transport.vfs.FileURI">vfs:sftp://user:pass@localhost/vfs/in</parameter>
+   <parameter name="transport.vfs.MoveAfterFailure">vfs:sftp://user:pass@localhost/vfs/failed</parameter>
+   <parameter name="transport.vfs.FileNamePattern">.*\.hl7</parameter>
+   <parameter name="transport.vfs.ContentType">application/edi-hl7;charset="iso-8859-15"</parameter>
+   <parameter name="transport.vfs.ActionAfterFailure">MOVE</parameter>
+   <parameter name="transport.hl7.ValidateMessage">false</parameter>
+   <description/>
+</proxy>
+```
+
+### Build and run
+
+Create the artifacts:
+
+1. [Set up WSO2 Integration Studio](../../../../develop/installing-WSO2-Integration-Studio).
+2. [Create an integration project](../../../../develop/create-integration-project) with an <b>ESB Configs</b> module and an <b>Composite Exporter</b>.
+3. [Create the proxy service](../../../../develop/creating-artifacts/creating-a-proxy-service) with the configurations given above.
+4. [Configure the HL7 transport](../../../../setup/transport_configurations/configuring-transports/#configuring-the-hl7-transport) in your Micro Integrator.
+5. [Deploy the artifacts](../../../../develop/deploy-artifacts) in your Micro Integrator.
+
+To test this scenario: 
+
+1.	Use an HL7 client (such as <b>HAPI</b>) to receive HL7 messages on the port specified as the endpoint (which is `9988`) in the above proxy service. 
+2.	Place an HL7 message in the `transport.vfs.FileURI` directory and see that the message passed to the HL7 endpoint in the HL7 client.

--- a/en/micro-integrator/mkdocs.yml
+++ b/en/micro-integrator/mkdocs.yml
@@ -206,6 +206,9 @@ nav:
           - 'Using the TCP Transport': 'use-cases/examples/transport_examples/tcp-transport-examples.md'
           - 'Using the FIX Transport': 'use-cases/examples/transport_examples/fix-transport-examples.md'
           - 'Using the MQTT Transport': 'use-cases/examples/transport_examples/Pub_Sub_using_MQTT.md'
+          - HL7 Examples:
+            - 'Mediating HL7 Messages': 'use-cases/examples/hl7-examples/HL7_proxy_service.md'
+            - 'Acknowledging HL7 Messages': 'use-cases/examples/hl7-examples/acknowledge_hl7_messages.md'
         - 'Working with Transactions': 'use-cases/examples/working-with-transactions.md'
         - 'JSON Examples': 'use-cases/examples/json_examples/json-examples.md'
     - Develop:

--- a/en/micro-integrator/mkdocs.yml
+++ b/en/micro-integrator/mkdocs.yml
@@ -209,6 +209,7 @@ nav:
           - HL7 Examples:
             - 'Mediating HL7 Messages': 'use-cases/examples/hl7-examples/HL7_proxy_service.md'
             - 'Acknowledging HL7 Messages': 'use-cases/examples/hl7-examples/acknowledge_hl7_messages.md'
+            - 'Using HL7 Messages with File Systems': 'use-cases/examples/hl7-examples/file_transfer_using_hl7.md'
         - 'Working with Transactions': 'use-cases/examples/working-with-transactions.md'
         - 'JSON Examples': 'use-cases/examples/json_examples/json-examples.md'
     - Develop:


### PR DESCRIPTION
HL7 documentation updated:

- HL7 message store docs removed (because the HL7 console, which was previously available in the management console is no longer available.
- Refactored the parameters, examples, and mediator properties.