### PR TITLE
(7.1.0 branch) HL7 message store related changes

### DIFF
--- a/en/micro-integrator/docs/overview/about-this-release-7.1.0.md
+++ b/en/micro-integrator/docs/overview/about-this-release-7.1.0.md
@@ -313,21 +313,10 @@ The following features, which are available in ESB runtimes, are removed from th
 	</tr>
 	<tr>
 		<td>
-			HL7 Console
-		</td>
-		<td>
-			The HL7 Console, which was available in the management console of previous ESBs, is removed in EI 7.x as it is not widely used.
-		</td>
-		<td>
-			-
-		</td>
-	</tr>
-	<tr>
-		<td>
 			HL7 Message Store
 		</td>
 		<td>
-			In previous ESBs, an HL7 Message Store could be configured using the custom message store implementation. Due to limited capabilities and tight coupling with the Hl7 console (which is now removed), this functionality is not usable in EI 7.x. 
+			In previous ESBs, an HL7 Message Store could be configured using the custom message store implementation. Due to limited capabilities and tight coupling with the Hl7 console (which was previously available in the management console), this functionality is not available in EI 7.x. 
 		</td>
 		<td>
 			-

--- a/en/micro-integrator/docs/overview/about-this-release-7.1.0.md
+++ b/en/micro-integrator/docs/overview/about-this-release-7.1.0.md
@@ -305,7 +305,29 @@ The following features, which are available in ESB runtimes, are removed from th
 			Rule Mediator
 		</td>
 		<td>
-			The rule mediator has been removed from Ei 7.1.0 as it is not widely used.
+			The rule mediator has been removed from EI 7.1.0 as it is not widely used.
+		</td>
+		<td>
+			-
+		</td>
+	</tr>
+	<tr>
+		<td>
+			HL7 Console
+		</td>
+		<td>
+			The HL7 Console, which was available in the management console of previous ESBs, is removed in EI 7.x as it is not widely used.
+		</td>
+		<td>
+			-
+		</td>
+	</tr>
+	<tr>
+		<td>
+			HL7 Message Store
+		</td>
+		<td>
+			In previous ESBs, an HL7 Message Store could be configured using the custom message store implementation. Due to limited capabilities and tight coupling with the Hl7 console (which is now removed), this functionality is not usable in EI 7.x. 
 		</td>
 		<td>
 			-

--- a/en/micro-integrator/docs/setup/deployment/migrating-from-ei-6.x.x.md
+++ b/en/micro-integrator/docs/setup/deployment/migrating-from-ei-6.x.x.md
@@ -106,7 +106,8 @@ The recommended way to create integration artifacts (in EI 6.x or EI 7.x ) is to
 Copy custom OSGI components in the `<EI_6.x.x_HOME>/dropins` folder to the `<MI_HOME>/dropins` folder. If you have custom JARs in the `<EI_6.x.x_HOME>/lib` directory, copy those components to the `<MI_HOME>/lib` directory.
 
 !!! Note
-    To provide seamless integration with RabbitMQ, the Rabbitmq client lib is included in the Micro Integrator by default. Hence, you don't need to manually add any RabbitMQ components.
+    -	To provide seamless integration with RabbitMQ, the Rabbitmq client lib is included in the Micro Integrator by default. Hence, you don't need to manually add any RabbitMQ components.
+    -	If you used an <b>HL7 Message Store</b> (custom message store) implementation, note that the Micro Integrator does not support this functionality. See the list of [removed features](../../../overview/about-this-release-7.1.0/#features-removed) for details.
 
 ### Migrating keystores
 Copy the JKS files in the `<EI_6.x.x_HOME>/repository/resources/security` directory to the `<MI_HOME>/repository/resources/security` directory. 

--- a/en/micro-integrator/docs/setup/deployment/migrating-from-esb-5.x.x.md
+++ b/en/micro-integrator/docs/setup/deployment/migrating-from-esb-5.x.x.md
@@ -137,7 +137,8 @@ The recommended way to create integration artifacts (in ESB 5.0 or EI 7.x ) is t
 Copy custom OSGI components in the `<ESB_5.0.0_HOME>/repository/components/dropins` folder to the `<MI_HOME>/dropins` folder. If you have custom JARs in the `<ESB_5.0.0_HOME>/repository/components/lib` folder, copy those components to the `<MI_HOME>/lib` directory.
 
 !!! Note
-    To provide seamless integration with RabbitMQ, the Rabbitmq client lib is included in the Micro Integrator by default. Hence, you don't need to manually add any RabbitMQ components.
+    -	To provide seamless integration with RabbitMQ, the Rabbitmq client lib is included in the Micro Integrator by default. Hence, you don't need to manually add any RabbitMQ components.
+    -	If you used an <b>HL7 Message Store</b> (custom message store) implementation, note that the Micro Integrator does not support this functionality. See the list of [removed features](../../../overview/about-this-release-7.1.0/#features-removed) for details.
 
 ### Migrating tenants
 

--- a/en/micro-integrator/docs/setup/transport_configurations/configuring-transports.md
+++ b/en/micro-integrator/docs/setup/transport_configurations/configuring-transports.md
@@ -143,6 +143,10 @@ protocol = "hl7"
 
 You can configure how long request threads wait for the application's response by specifying the `parameter.'transport.hl7.TimeOut'` parameter as shown above. This configures the timeout in milliseconds at the transport level.
 
+### Change message encoding type
+
+To control the encoding type of incoming HL7 messages, set the following JAVA system property: `ca.uhn.hl7v2.llp.charset`.
+
 ## Configuring the TCP transport
 
 To enable the TCP transport listener and sender, set the following parameters to `true` in the deployment.toml file (stored in the `MI_HOME/conf` directory).


### PR DESCRIPTION
Since the HL7 message store is not supported in the Micro Integrator, updating the docs accordingly.