### PR TITLE
(7.1.0 branch) updating site URL to latest

### DIFF
--- a/en/micro-integrator/mkdocs.yml
+++ b/en/micro-integrator/mkdocs.yml
@@ -18,7 +18,7 @@
 site_name: WSO2 Enterprise Integrator Documentation
 site_description: Documentation for WSO2 Enterprise Integrator
 site_author: WSO2
-site_url: https://ei.docs.wso2.com/en/7.1.0/
+site_url: https://ei.docs.wso2.com/en/latest/
 
 # Repository
 repo_name: wso2/docs-ei


### PR DESCRIPTION
Changes the site URL to 'latest' as opposed to saying '7.1.0'. 
This is expected to help SEO.
Same practice is used in APIM docs