### PR TITLE
(7.0.0 branch) Update site URL of MI DOCS

### DIFF
--- a/en/micro-integrator/mkdocs.yml
+++ b/en/micro-integrator/mkdocs.yml
@@ -18,7 +18,7 @@
 site_name: WSO2 Enterprise Integrator Documentation
 site_description: Documentation for WSO2 Enterprise Integrator
 site_author: WSO2
-site_url: https://ei.docs.wso2.com/en/latest/
+site_url: https://ei.docs.wso2.com/en/7.0.0/
 
 # Repository
 repo_name: wso2/docs-ei


### PR DESCRIPTION
Changed site URL to 7.0.0 instead of latest.
Expected to improve SEO.