### PR TITLE
(7.0.0 branch) update site URL for SI DOCS

### DIFF
--- a/en/streaming-integrator/mkdocs.yml
+++ b/en/streaming-integrator/mkdocs.yml
@@ -18,7 +18,7 @@
 site_name: WSO2 Enterprise Integrator Documentation
 site_description: Documentation for WSO2 Enterprise Integrator
 site_author: WSO2
-site_url: https://ei.docs.wso2.com/en/latest/
+site_url: https://ei.docs.wso2.com/en/7.0.0/
 
 # Repository
 repo_name: wso2/docs-ei


### PR DESCRIPTION
changed site URL to 7.0.0 instead of latest.
This is expected to improve SEO.