### PR TITLE
(7.1.0 Branch) Installation location

### DIFF
--- a/en/micro-integrator/docs/setup/installation/install_in_vm_installer.md
+++ b/en/micro-integrator/docs/setup/installation/install_in_vm_installer.md
@@ -152,7 +152,7 @@ See the [Micro Integrator Dashboard](../../../administer-and-observe/working-wit
    <tbody>
       <tr class="odd">
          <td>Mac OS</td>
-         <td><code>/Library/WSO2/wso2ei/7.1.0/micro-integrator</code></td>
+         <td><code>/Library/WSO2/EnterpriseIntegrator/7.1.0/micro-integrator</code></td>
       </tr>
       <tr class="even">
          <td>Windows</td>
@@ -187,7 +187,7 @@ See the [Micro Integrator Dashboard](../../../administer-and-observe/working-wit
    <tbody>
       <tr class="odd">
          <td>Mac OS</td>
-         <td><code>/Library/WSO2/wso2ei/7.1.0/micro-integrator-dashboard</code></td>
+         <td><code>/Library/WSO2/EnterpriseIntegrator/7.1.0/micro-integrator-dashboard</code></td>
       </tr>
       <tr class="even">
          <td>Windows</td>
@@ -220,7 +220,7 @@ If you used the **installer** to install WSO2 Enterprise Integrator, you can uni
 <td>Mac OS</td>
 <td><div class="content-wrapper">
 <p>Open a terminal and run the following command as the root user:</p>
-  <code>sudo bash /Library/WSO2/wso2ei/7.1.0/uninstall.sh</code>
+  <code>sudo bash /Library/WSO2/EnterpriseIntegrator/7.1.0/uninstall.sh</code>
 </div>
 </div>
 </div></td>


### PR DESCRIPTION
The installation location changed from 'wso2ei' to 'EnterpriseIntegrator' for MacOS.
Verified on Mac.
Need to test for CentOs and Linux.