### PR TITLE
(master branch) fixing 'edit url' in the yml

### DIFF
--- a/en/micro-integrator/mkdocs.yml
+++ b/en/micro-integrator/mkdocs.yml
@@ -23,7 +23,7 @@ site_url: https://ei.docs.wso2.com/en/7.2.0/
 # Repository
 repo_name: wso2/docs-ei
 repo_url: https://github.com/wso2/docs-ei
-edit_uri: https://github.com/wso2/docs-ei/edit/7.2.0/en/micro-integrator/docs/
+edit_uri: https://github.com/wso2/docs-ei/edit/master/en/micro-integrator/docs/
 
 # Copyright
 copyright: WSO2 Enterprise Integrator - Documentation


### PR DESCRIPTION
THe edit url should point to 'master' not '7.2.0'.
There is no branch named '7.2.0'.