### PR TITLE
Update configuring_keystores documentation

### DIFF
--- a/en/micro-integrator/docs/setup/security/configuring_keystores.md
+++ b/en/micro-integrator/docs/setup/security/configuring_keystores.md
@@ -21,12 +21,23 @@ The **default trust store** contains the certificates of reputed CAs that can va
 
 If you want to change the [default primary keystore](#the-default-keystore-configuration) that is shipped with the product, follow the steps given below.
 
-1. [Create a new keystore](../../setup/security/creating_keystores.md) and copy it to the MI_HOME/repository/security/ directory.
-  
+1. [Create a new keystore](../../setup/security/creating_keystores). 
+
     !!! Note
         CA-signed certificates are recommended for this keystore because it is used for communicating with external parties.
 
-2. Open the deployment.toml file, add the following config section, and update the parameter values for the newly-created keystore.
+2.  You can copy the new file to the `<MI_HOME>/repository/security/` folder. 
+
+    !!! Note
+        You can use a custom location <b>only</b> if you are using an updated version of the Micro Integrator. Read the below instructions for details.
+
+3. Open the deployment.toml file, add the following config section, and update the parameter values for the newly-created keystore.
+
+    !!! Warning
+        WSO2 released a product update on <b>17/09/2020</b>, which requires that you provide the full path to your keystore file. If you don't already have this  update, you can [get the latest updates](https://updates.docs.wso2.com/en/latest/updates/overview/) now.
+
+        If you are not using the product update, you should only specify the keystore name in the configuration (`file_name="wso2carbon.jks"`). Also, be sure to have the keystore file in the default `<MI_HOME>/repository/security/` folder. Custom keystore locations cannot be used without the product update.
+
     ```toml
     [keystore.primary]
     file_name="repository/resources/security/wso2carbon.jks"
@@ -37,16 +48,6 @@ If you want to change the [default primary keystore](#the-default-keystore-confi
     ```
     Find more details about [keystore parameters](../../../references/config-catalog/#primary-keystore).
     
-    !!! Note
-        If you are using the pack (without any WUM update released after 09/17/2020), you need to use the following configuration,
-            ```[keystore.tls]
-               file_name="wso2carbon.jks"
-               type="JKS"
-               password="wso2carbon"
-               alias="wso2carbon"
-               key_password="wso2carbon" 
-           ```
-           
 3. [Import the required CA-signed certificates](../../setup/security/importing_ssl_certificate.md) to the key store.
 
 ## Separating the internal keystore
@@ -59,12 +60,23 @@ By default, the [primary keystore](#the-default-keystore-configuration) is used 
 
 Follow the steps given below to separate the keystore that is used for encrypting data in internal data stores.
 
-1. [Create a new keystore](../../setup/security/creating_keystores.md) and copy it to the MI_HOME/repository/security/ directory.
-  
-    !!! Note
-        You do not require CA-signed certificates for this keystore because it will **not** be used for communicating with external parties.
+1. [Create a new keystore](../../setup/security/creating_keystores). 
 
-2. Open the deployment.toml file, and update the parameter values for the newly-created internal keystore.
+    !!! Note
+        CA-signed certificates are recommended for this keystore because it is used for communicating with external parties.
+
+2.  You can copy the new file to the `<MI_HOME>/repository/security/` folder. 
+
+    !!! Note
+        You can use a custom location <b>only</b> if you are using an updated version of the Micro Integrator. Read the below instructions for details.
+
+3. Open the deployment.toml file, and update the parameter values for the newly-created internal keystore.
+
+    !!! Warning
+        WSO2 released a product update on <b>17/09/2020</b>, which requires that you provide the full path to your keystore file. If you don't already have this  update, you can [get the latest updates](https://updates.docs.wso2.com/en/latest/updates/overview/) now.
+
+        If you are not using the product update, you should only specify the keystore name in the configuration (`file_name="wso2carbon.jks"`). Also, be sure to have the keystore file in the default `<MI_HOME>/repository/security/` folder. Custom keystore locations cannot be used without the product update.
+        
     ```toml
     [keystore.internal]
     file_name="repository/resources/security/wso2carbon.jks"
@@ -74,9 +86,6 @@ Follow the steps given below to separate the keystore that is used for encryptin
     key_password="wso2carbon"
     ```
     Find more details about [internal keystore parameters](../../../references/config-catalog/#internal-keystore).
-    
-    !!! Note
-        If you are using the pack (without any WUM update released after 09/17/2020), you need to configure the file_name parameter without file location as <b>file_name="wso2carbon.jks"</b>.
             
 ## Optional: Changing the default truststore
 If you want to change the [default trust store](#the-default-keystore-configuration) that is shipped with the product, follow the steps given below.

--- a/en/micro-integrator/docs/setup/security/configuring_keystores.md
+++ b/en/micro-integrator/docs/setup/security/configuring_keystores.md
@@ -29,14 +29,17 @@ If you want to change the [default primary keystore](#the-default-keystore-confi
 2. Open the deployment.toml file, add the following config section, and update the parameter values for the newly-created keystore.
     ```toml
     [keystore.primary]
-    file_name="wso2carbon.jks"
+    file_name="repository/resources/security/wso2carbon.jks"
     type="JKS"
     password="wso2carbon"
     alias="wso2carbon"
     key_password="wso2carbon"
     ```
     Find more details about [keystore parameters](../../../references/config-catalog/#primary-keystore).
-
+    
+    !!! Note
+        If you are using the vanilla pack (without any WUM updates), you need to configure the file_name parameter without file location as <b>file_name="wso2carbon.jks"</b>.
+            
 3. [Import the required CA-signed certificates](../../setup/security/importing_ssl_certificate.md) to the key store.
 
 ## Separating the internal keystore
@@ -57,14 +60,17 @@ Follow the steps given below to separate the keystore that is used for encryptin
 2. Open the deployment.toml file, and update the parameter values for the newly-created internal keystore.
     ```toml
     [keystore.internal]
-    file_name="wso2carbon.jks"
+    file_name="repository/resources/security/wso2carbon.jks"
     type="JKS"
     password="wso2carbon"
     alias="wso2carbon"
     key_password="wso2carbon"
     ```
     Find more details about [internal keystore parameters](../../../references/config-catalog/#internal-keystore).
-
+    
+    !!! Note
+        If you are using the vanilla pack (without any WUM updates), you need to configure the file_name parameter without file location as <b>file_name="wso2carbon.jks"</b>.
+            
 ## Optional: Changing the default truststore
 If you want to change the [default trust store](#the-default-keystore-configuration) that is shipped with the product, follow the steps given below.
 
@@ -76,10 +82,14 @@ If you want to change the [default trust store](#the-default-keystore-configurat
 2. Open the deployment.toml file, add the following config section and update the values for the newly-created trust store.
     ```toml
     [truststore]
-    file_name="wso2carbon.jks"
+    file_name="repository/resources/security/client-truststore.jks"
     type="JKS"
     password="wso2carbon"
     alias="symmetric.key.value"
-    algorithm=""
+    algorithm="AES"
     ```
+    
+    !!! Note
+        If you are using the vanilla pack (without any WUM updates), you need to configure the file_name parameter without file location as <b>file_name="client-truststore.jks"</b>.
+            
 3. [Import the required certificates](../../setup/security/importing_ssl_certificate.md#importing-ssl-certificates-to-a-truststore) to the trust store.

--- a/en/micro-integrator/docs/setup/security/configuring_keystores.md
+++ b/en/micro-integrator/docs/setup/security/configuring_keystores.md
@@ -31,21 +31,36 @@ If you want to change the [default primary keystore](#the-default-keystore-confi
     !!! Note
         You can use a custom location <b>only</b> if you are using an updated version of the Micro Integrator. Read the below instructions for details.
 
-3. Open the deployment.toml file, add the following config section, and update the parameter values for the newly-created keystore.
+3. Open the `deployment.toml` file add the relevant configurations (as described below).
 
-    !!! Warning
-        WSO2 released a product update on <b>17/09/2020</b>, which requires that you provide the full path to your keystore file. If you don't already have this  update, you can [get the latest updates](https://updates.docs.wso2.com/en/latest/updates/overview/) now.
+    -   If you are using an [updated](https://updates.docs.wso2.com/en/latest/updates/overview/) Micro Integrator, use the following configuration and change the values. 
 
-        If you are not using the product update, you should only specify the keystore name in the configuration (`file_name="wso2carbon.jks"`). Also, be sure to have the keystore file in the default `<MI_HOME>/repository/security/` folder. Custom keystore locations cannot be used without the product update.
+        !!! Info
+            WSO2 released a product update on <b>17/09/2020</b>, which requires that you provide the full path to your keystore file in your configuration as shown below. If you don't already have this update, you can [get the latest updates](https://updates.docs.wso2.com/en/latest/updates/overview/) now.
 
-    ```toml
-    [keystore.primary]
-    file_name="repository/resources/security/wso2carbon.jks"
-    type="JKS"
-    password="wso2carbon"
-    alias="wso2carbon"
-    key_password="wso2carbon"
-    ```
+        ```toml
+        [keystore.primary]
+        file_name="repository/resources/security/wso2carbon.jks"
+        type="JKS"
+        password="wso2carbon"
+        alias="wso2carbon"
+        key_password="wso2carbon"
+        ```
+
+    -   If you are using a Micro Integrator <b>without</b> updates, use the following configuration and change the values. 
+
+        !!! Info
+            Be sure to replace `[keystore.primary]` with `[keystore.tls]` and specify the keystore name instead of the file path. Also, be sure to store the keystore file in the default `<MI_HOME>/repository/security/` folder. Custom keystore locations cannot be used without the product update.
+
+        ```toml
+        [keystore.tls]
+        file_name="wso2carbon.jks"
+        type="JKS"
+        password="wso2carbon"
+        alias="wso2carbon"
+        key_password="wso2carbon"
+        ```
+
     Find more details about [keystore parameters](../../../references/config-catalog/#primary-keystore).
     
 3. [Import the required CA-signed certificates](../../setup/security/importing_ssl_certificate.md) to the key store.
@@ -70,21 +85,35 @@ Follow the steps given below to separate the keystore that is used for encryptin
     !!! Note
         You can use a custom location <b>only</b> if you are using an updated version of the Micro Integrator. Read the below instructions for details.
 
-3. Open the deployment.toml file, and update the parameter values for the newly-created internal keystore.
+3.  Open the `deployment.toml` file add the relevant configurations (as described below).
 
-    !!! Warning
-        WSO2 released a product update on <b>17/09/2020</b>, which requires that you provide the full path to your keystore file. If you don't already have this  update, you can [get the latest updates](https://updates.docs.wso2.com/en/latest/updates/overview/) now.
+    -   If you are using an [updated](https://updates.docs.wso2.com/en/latest/updates/overview/) Micro Integrator, use the following configuration and change the values. 
 
-        If you are not using the product update, you should only specify the keystore name in the configuration (`file_name="wso2carbon.jks"`). Also, be sure to have the keystore file in the default `<MI_HOME>/repository/security/` folder. Custom keystore locations cannot be used without the product update.
-        
-    ```toml
-    [keystore.internal]
-    file_name="repository/resources/security/wso2carbon.jks"
-    type="JKS"
-    password="wso2carbon"
-    alias="wso2carbon"
-    key_password="wso2carbon"
-    ```
+        !!! Info
+            WSO2 released a product update on <b>17/09/2020</b>, which requires that you provide the full path to your keystore file in your configuration as shown below. If you don't already have this update, you can [get the latest updates](https://updates.docs.wso2.com/en/latest/updates/overview/) now.
+
+        ```toml
+        [keystore.internal]
+        file_name="repository/resources/security/wso2carbon.jks"
+        type="JKS"
+        password="wso2carbon"
+        alias="wso2carbon"
+        key_password="wso2carbon"
+        ```
+
+    -   If you are using a Micro Integrator <b>without</b> updates, use the following configuration and change the values. 
+
+        !!! Info
+            Be sure to specify the keystore name instead of the file path. Also, be sure to store the keystore file in the default `<MI_HOME>/repository/security/` folder. Custom keystore locations cannot be used without the product update.
+
+        ```toml
+        [keystore.internal]
+        file_name="wso2carbon.jks"
+        type="JKS"
+        password="wso2carbon"
+        alias="wso2carbon"
+        key_password="wso2carbon"
+        ```
     Find more details about [internal keystore parameters](../../../references/config-catalog/#internal-keystore).
             
 ## Optional: Changing the default truststore

--- a/en/micro-integrator/docs/setup/security/configuring_keystores.md
+++ b/en/micro-integrator/docs/setup/security/configuring_keystores.md
@@ -26,7 +26,7 @@ If you want to change the [default primary keystore](#the-default-keystore-confi
     !!! Note
         CA-signed certificates are recommended for this keystore because it is used for communicating with external parties.
 
-2.  You can copy the new file to the `<MI_HOME>/repository/security/` folder. 
+2.  You can copy the new file to the `<MI_HOME>/repository/resources/security/` folder. 
 
     !!! Note
         You can use a custom location <b>only</b> if you are using an updated version of the Micro Integrator. Read the below instructions for details.
@@ -50,7 +50,7 @@ If you want to change the [default primary keystore](#the-default-keystore-confi
     -   If you are using a Micro Integrator <b>without</b> updates, use the following configuration and change the values. 
 
         !!! Info
-            Be sure to replace `[keystore.primary]` with `[keystore.tls]` and specify the keystore name instead of the file path. Also, be sure to store the keystore file in the default `<MI_HOME>/repository/security/` folder. Custom keystore locations cannot be used without the product update.
+            Be sure to replace `[keystore.primary]` with `[keystore.tls]` and specify the keystore name instead of the file path. Also, be sure to store the keystore file in the default `<MI_HOME>/repository/resources/security/` folder. Custom keystore locations cannot be used without the product update.
 
         ```toml
         [keystore.tls]
@@ -80,7 +80,7 @@ Follow the steps given below to separate the keystore that is used for encryptin
     !!! Note
         CA-signed certificates are recommended for this keystore because it is used for communicating with external parties.
 
-2.  You can copy the new file to the `<MI_HOME>/repository/security/` folder. 
+2.  You can copy the new file to the `<MI_HOME>/repository/resources/security/` folder. 
 
     !!! Note
         You can use a custom location <b>only</b> if you are using an updated version of the Micro Integrator. Read the below instructions for details.
@@ -104,7 +104,7 @@ Follow the steps given below to separate the keystore that is used for encryptin
     -   If you are using a Micro Integrator <b>without</b> updates, use the following configuration and change the values. 
 
         !!! Info
-            Be sure to specify the keystore name instead of the file path. Also, be sure to store the keystore file in the default `<MI_HOME>/repository/security/` folder. Custom keystore locations cannot be used without the product update.
+            Be sure to specify the keystore name instead of the file path. Also, be sure to store the keystore file in the default `<MI_HOME>/repository/resources/security/` folder. Custom keystore locations cannot be used without the product update.
 
         ```toml
         [keystore.internal]
@@ -117,24 +117,46 @@ Follow the steps given below to separate the keystore that is used for encryptin
     Find more details about [internal keystore parameters](../../../references/config-catalog/#internal-keystore).
             
 ## Optional: Changing the default truststore
-If you want to change the [default trust store](#the-default-keystore-configuration) that is shipped with the product, follow the steps given below.
+If you want to change the [default truststore](#the-default-keystore-configuration) that is shipped with the product, follow the steps given below.
 
-1. [Create a new keystore](../../setup/security/creating_keystores.md) and copy it to the MI_HOME/repository/security/ directory.
+1. [Create a new keystore](../../setup/security/creating_keystores). 
 
-    !!! Note 
-        You do not require CA-signed certificates for this keystore.
+    !!! Note
+        CA-signed certificates are recommended for this keystore because it is used for communicating with external parties.
+
+2.  You can copy the new file to the `<MI_HOME>/repository/resources/security/` folder. 
+
+    !!! Note
+        You can use a custom location <b>only</b> if you are using an updated version of the Micro Integrator. Read the below instructions for details.
 
 2. Open the deployment.toml file, add the following config section and update the values for the newly-created trust store.
-    ```toml
-    [truststore]
-    file_name="repository/resources/security/client-truststore.jks"
-    type="JKS"
-    password="wso2carbon"
-    alias="symmetric.key.value"
-    algorithm="AES"
-    ```
-    
-    !!! Note
-        If you are using the pack (without any WUM update released after 09/17/2020), you need to configure the file_name parameter without file location as <b>file_name="client-truststore.jks"</b>.
+
+    -   If you are using an [updated](https://updates.docs.wso2.com/en/latest/updates/overview/) Micro Integrator, use the following configuration and change the values. 
+
+        !!! Info
+            WSO2 released a product update on <b>17/09/2020</b>, which requires that you provide the full path to your truststore file in your configuration as shown below. If you don't already have this update, you can [get the latest updates](https://updates.docs.wso2.com/en/latest/updates/overview/) now.
+
+        ```toml
+        [truststore]
+        file_name="repository/resources/security/client-truststore.jks"
+        type="JKS"
+        password="wso2carbon"
+        alias="symmetric.key.value"
+        algorithm="AES"
+        ```
+
+    -   If you are using a Micro Integrator <b>without</b> updates, use the following configuration and change the values. 
+
+        !!! Info
+            Be sure to specify the truststore name instead of the file path. Also, be sure to store the truststore file in the default `<MI_HOME>/repository/resources/security/` folder. Custom locations cannot be used without the product update.
+
+        ```toml
+        [truststore]
+        file_name="client-truststore.jks"
+        type="JKS"
+        password="wso2carbon"
+        alias="symmetric.key.value"
+        algorithm="AES"
+        ```
             
-3. [Import the required certificates](../../setup/security/importing_ssl_certificate.md#importing-ssl-certificates-to-a-truststore) to the trust store.
+3. [Import the required certificates](../../setup/security/importing_ssl_certificate.md#importing-ssl-certificates-to-a-truststore) to the truststore.

--- a/en/micro-integrator/docs/setup/security/configuring_keystores.md
+++ b/en/micro-integrator/docs/setup/security/configuring_keystores.md
@@ -38,8 +38,15 @@ If you want to change the [default primary keystore](#the-default-keystore-confi
     Find more details about [keystore parameters](../../../references/config-catalog/#primary-keystore).
     
     !!! Note
-        If you are using the vanilla pack (without any WUM updates), you need to configure the file_name parameter without file location as <b>file_name="wso2carbon.jks"</b>.
-            
+        If you are using the pack (without any WUM update released after 09/17/2020), you need to use the following configuration,
+            ```[keystore.tls]
+               file_name="wso2carbon.jks"
+               type="JKS"
+               password="wso2carbon"
+               alias="wso2carbon"
+               key_password="wso2carbon" 
+           ```
+           
 3. [Import the required CA-signed certificates](../../setup/security/importing_ssl_certificate.md) to the key store.
 
 ## Separating the internal keystore
@@ -69,7 +76,7 @@ Follow the steps given below to separate the keystore that is used for encryptin
     Find more details about [internal keystore parameters](../../../references/config-catalog/#internal-keystore).
     
     !!! Note
-        If you are using the vanilla pack (without any WUM updates), you need to configure the file_name parameter without file location as <b>file_name="wso2carbon.jks"</b>.
+        If you are using the pack (without any WUM update released after 09/17/2020), you need to configure the file_name parameter without file location as <b>file_name="wso2carbon.jks"</b>.
             
 ## Optional: Changing the default truststore
 If you want to change the [default trust store](#the-default-keystore-configuration) that is shipped with the product, follow the steps given below.
@@ -90,6 +97,6 @@ If you want to change the [default trust store](#the-default-keystore-configurat
     ```
     
     !!! Note
-        If you are using the vanilla pack (without any WUM updates), you need to configure the file_name parameter without file location as <b>file_name="client-truststore.jks"</b>.
+        If you are using the pack (without any WUM update released after 09/17/2020), you need to configure the file_name parameter without file location as <b>file_name="client-truststore.jks"</b>.
             
 3. [Import the required certificates](../../setup/security/importing_ssl_certificate.md#importing-ssl-certificates-to-a-truststore) to the trust store.


### PR DESCRIPTION
## Purpose
Update configuring keystores documentation to reflect the changes done in https://github.com/wso2-support/micro-integrator/pull/39.
We have added support to define keystore file location instead of file name,
```
[keystore.primary]
file_name = "repository/resources/security/wso2carbon.jks"
password = "wso2carbon"
alias = "wso2carbon"
key_password = "wso2carbon"
```