### PR TITLE
Correct the URL to access Business Rules mentioned in documentation and remove references to obsolete APIs

### DIFF
--- a/en/streaming-integrator/docs/admin/creating-business-rules-templates.md
+++ b/en/streaming-integrator/docs/admin/creating-business-rules-templates.md
@@ -21,15 +21,10 @@ To create a business rule from a template, follow the procedure below:
     - On Windows: `tooling.bat --run`
     - On Linux/Mac OS:  `./tooling.sh`
 
-2. Access the Business Rule Manager via one of the following URLs.
-
-    | Protocol | URL Format                                      | Example                               |
-    |----------|-------------------------------------------------|---------------------------------------|
-    | HTTP     | `http://<SI_TOOLING_HOST>:<HTTP_PORT>/business-rules`   | `http://0.0.0.0:9090/business-rules`  |
-    | HTTPS    | `https://<SI_TOOLING_HOST>:<HTTPS_PORT>/business-rules` | `https://0.0.0.0:9443/business-rules` |
-
-    !!!tip
-        The URLs given above are the defaul URLs. If required, you can change the host name (i.e., `0.0.0.0`) or the web UI application name (i.e., `business-rules`). For instructions, see [Changing the Host Name and Context Path of SI Tooling](../setup/change-hostname-and-context-path.md).
+2. Access the Business Rule Manager via the URL that appears in the terminal for Business Rules in the `https://<SI_TOOLING_HOST>:<HTTPS_PORT>/business-rules` format.
+    
+    !!! tip
+        The default URL is `https://0.0.0.0:9743/business-rules`. If required, you can change the host name (i.e., `0.0.0.0`) or the web UI application name (i.e., `business-rules`). For instructions, see [Changing the Host Name and Context Path of SI Tooling](../setup/change-hostname-and-context-path.md).
         
     This opens the following:
 

--- a/en/streaming-integrator/docs/ref/rest-api-guide-overview.md
+++ b/en/streaming-integrator/docs/ref/rest-api-guide-overview.md
@@ -6,10 +6,6 @@ The following REST API categories are supported for WSO2 Streaming Integrator:
 
     The supported APIs allow you to manage Siddhi applications by creating, updating and deleting them as required. You can also fetch a Siddhi applications, enable statistics for them, retrieve them take snapshots of them etc.
 
-- [**Event Simulation APIs**](event-simulation-apis.md)
-
-    The supported APIs allow you to manange event simulations. You can create them as well as run them and manage them. The supported APIs cover actions for all four types of simulation (i.e., single event simulation, and multiple event simulation via file, database and random events).
-
 - [**Permission APIs**](permission-apis.md)
 
     The supported APIs allow you to add permission strings, getting a permission ID for a given string and checking whether a specific user role is granted a specific permission.


### PR DESCRIPTION
## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
