### PR TITLE
[SI] Add note regarding checking binlog status in MySQL 8 for CDC

### DIFF
--- a/en/streaming-integrator/docs/examples/creating-etl-application-via-tooling.md
+++ b/en/streaming-integrator/docs/examples/creating-etl-application-via-tooling.md
@@ -16,7 +16,7 @@ In this tutorial, let's create the same Siddhi application created in [Performin
 
 !!!info "Before you begin:"
     - You need to have access to a MySQL instance.<br/>
-    - Enable binary logging in the MySQL server. For detailed instructions, see [Enabling the Binlog tutorial by debezium](https://debezium.io/docs/connectors/mysql/#enabling-the-binlog).<br/>
+    - Enable binary logging in the MySQL server. For detailed instructions, see [Debezium documentation - Enabling the binlog](https://debezium.io/docs/connectors/mysql/#enabling-the-binlog).<br/>
 
         !!!note
             If you are using MySQL 8.0, use the following query to check the binlog status:

--- a/en/streaming-integrator/docs/examples/creating-etl-application-via-tooling.md
+++ b/en/streaming-integrator/docs/examples/creating-etl-application-via-tooling.md
@@ -17,6 +17,14 @@ In this tutorial, let's create the same Siddhi application created in [Performin
 !!!info "Before you begin:"
     - You need to have access to a MySQL instance.<br/>
     - Enable binary logging in the MySQL server. For detailed instructions, see [Enabling the Binlog tutorial by debezium](https://debezium.io/docs/connectors/mysql/#enabling-the-binlog).<br/>
+
+        !!!note
+            If you are using MySQL 8.0, please use the following query to check the binlog status:
+            ```
+            SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
+            FROM performance_schema.global_variables WHERE variable_name='log_bin';
+            ```
+
     - Add the MySQL JDBC driver into the `<SI_HOME>/lib` directory as follows:<br/>
         1. Download the MySQL JDBC driver from [the MySQL site](https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.45.tar.gz).<br/>
         2. Unzip the archive.<br/>

--- a/en/streaming-integrator/docs/examples/creating-etl-application-via-tooling.md
+++ b/en/streaming-integrator/docs/examples/creating-etl-application-via-tooling.md
@@ -19,7 +19,7 @@ In this tutorial, let's create the same Siddhi application created in [Performin
     - Enable binary logging in the MySQL server. For detailed instructions, see [Enabling the Binlog tutorial by debezium](https://debezium.io/docs/connectors/mysql/#enabling-the-binlog).<br/>
 
         !!!note
-            If you are using MySQL 8.0, please use the following query to check the binlog status:
+            If you are using MySQL 8.0, use the following query to check the binlog status:
             ```
             SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
             FROM performance_schema.global_variables WHERE variable_name='log_bin';

--- a/en/streaming-integrator/docs/examples/performing-real-time-etl-with-mysql.md
+++ b/en/streaming-integrator/docs/examples/performing-real-time-etl-with-mysql.md
@@ -37,7 +37,7 @@ You can capture following type of changes done to a database table:
     - Enable binary logging in the MySQL server. For detailed instructions, see [Enabling the Binlog tutorial by debezium](https://debezium.io/docs/connectors/mysql/#enabling-the-binlog).<br/>
 
         !!!note
-            If you are using MySQL 8.0, please use the following query to check the binlog status:
+            If you are using MySQL 8.0, use the following query to check the binlog status:
             ```
             SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
             FROM performance_schema.global_variables WHERE variable_name='log_bin';

--- a/en/streaming-integrator/docs/examples/performing-real-time-etl-with-mysql.md
+++ b/en/streaming-integrator/docs/examples/performing-real-time-etl-with-mysql.md
@@ -34,7 +34,7 @@ You can capture following type of changes done to a database table:
 
 !!!info "Before you begin:"
     - You need to have access to a MySQL instance.<br/>
-    - Enable binary logging in the MySQL server. For detailed instructions, see [Enabling the Binlog tutorial by debezium](https://debezium.io/docs/connectors/mysql/#enabling-the-binlog).<br/>
+    - Enable binary logging in the MySQL server. For detailed instructions, see [Debezium documentation - Enabling the binlog](https://debezium.io/docs/connectors/mysql/#enabling-the-binlog).<br/>
 
         !!!note
             If you are using MySQL 8.0, use the following query to check the binlog status:

--- a/en/streaming-integrator/docs/examples/performing-real-time-etl-with-mysql.md
+++ b/en/streaming-integrator/docs/examples/performing-real-time-etl-with-mysql.md
@@ -35,6 +35,14 @@ You can capture following type of changes done to a database table:
 !!!info "Before you begin:"
     - You need to have access to a MySQL instance.<br/>
     - Enable binary logging in the MySQL server. For detailed instructions, see [Enabling the Binlog tutorial by debezium](https://debezium.io/docs/connectors/mysql/#enabling-the-binlog).<br/>
+
+        !!!note
+            If you are using MySQL 8.0, please use the following query to check the binlog status:
+            ```
+            SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
+            FROM performance_schema.global_variables WHERE variable_name='log_bin';
+            ```
+
     - Add the MySQL JDBC driver into the `<SI_HOME>/lib` directoryas follows:<br/>
         1. Download the MySQL JDBC driver from [the MySQL site](https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.45.tar.gz).<br/>
         2. Unzip the archive.<br/>

--- a/en/streaming-integrator/docs/guides/extracting-data-from-static-sources-in-real-time.md
+++ b/en/streaming-integrator/docs/guides/extracting-data-from-static-sources-in-real-time.md
@@ -90,7 +90,7 @@ Let's try out the example where you want to view the online bookings saved in a 
 2. Enable binary logging in the MySQL server. For detailed instructions, see [Enabling the Binlog tutorial by debezium](https://debezium.io/docs/connectors/mysql/#enabling-the-binlog).
 
     !!!note
-        If you are using MySQL 8.0, please use the following query to check the binlog status:
+        If you are using MySQL 8.0, use the following query to check the binlog status:
         ```
         SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
         FROM performance_schema.global_variables WHERE variable_name='log_bin';

--- a/en/streaming-integrator/docs/guides/extracting-data-from-static-sources-in-real-time.md
+++ b/en/streaming-integrator/docs/guides/extracting-data-from-static-sources-in-real-time.md
@@ -89,6 +89,13 @@ Let's try out the example where you want to view the online bookings saved in a 
 
 2. Enable binary logging in the MySQL server. For detailed instructions, see [Enabling the Binlog tutorial by debezium](https://debezium.io/docs/connectors/mysql/#enabling-the-binlog).
 
+    !!!note
+        If you are using MySQL 8.0, please use the following query to check the binlog status:
+        ```
+        SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
+        FROM performance_schema.global_variables WHERE variable_name='log_bin';
+        ```
+
 3. Start the MySQL server, create the database and the database table you require as follows:
 
     1. To create a new database, issue the following MySQL command.

--- a/en/streaming-integrator/docs/guides/extracting-data-from-static-sources-in-real-time.md
+++ b/en/streaming-integrator/docs/guides/extracting-data-from-static-sources-in-real-time.md
@@ -87,7 +87,7 @@ Let's try out the example where you want to view the online bookings saved in a 
 
 1. Download and install MySQL.
 
-2. Enable binary logging in the MySQL server. For detailed instructions, see [Enabling the Binlog tutorial by debezium](https://debezium.io/docs/connectors/mysql/#enabling-the-binlog).
+2. Enable binary logging in the MySQL server. For detailed instructions, see [Debezium documentation - Enabling the binlog](https://debezium.io/docs/connectors/mysql/#enabling-the-binlog).
 
     !!!note
         If you are using MySQL 8.0, use the following query to check the binlog status:

--- a/en/streaming-integrator/docs/quick-start-guide/getting-started/download-install-and-start-si.md
+++ b/en/streaming-integrator/docs/quick-start-guide/getting-started/download-install-and-start-si.md
@@ -22,7 +22,14 @@ In this scenario, the Streaming Integrator reads input data from a MySQL databas
 
 1. Download MySQL 5.1.49 from [MySQL Community Downloads](https://dev.mysql.com/downloads/connector/j/5.1.html).
 
-2. Enable binary logging in the MySQL server. For detailed instructions, see [Enabling the Binlog tutorial by debezium](https://debezium.io/docs/connectors/mysql/#enabling-the-binlog).    
+2. Enable binary logging in the MySQL server. For detailed instructions, see [Enabling the Binlog tutorial by debezium](https://debezium.io/docs/connectors/mysql/#enabling-the-binlog).  
+
+    !!!note
+        If you are using MySQL 8.0, please use the following query to check the binlog status:
+        ```
+        SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
+        FROM performance_schema.global_variables WHERE variable_name='log_bin';
+        ```
     
 3. Once you install MySQL and start the MySQL server, create the database and the database table you require as follows:
 

--- a/en/streaming-integrator/docs/quick-start-guide/getting-started/download-install-and-start-si.md
+++ b/en/streaming-integrator/docs/quick-start-guide/getting-started/download-install-and-start-si.md
@@ -22,7 +22,7 @@ In this scenario, the Streaming Integrator reads input data from a MySQL databas
 
 1. Download MySQL 5.1.49 from [MySQL Community Downloads](https://dev.mysql.com/downloads/connector/j/5.1.html).
 
-2. Enable binary logging in the MySQL server. For detailed instructions, see [Enabling the Binlog tutorial by debezium](https://debezium.io/docs/connectors/mysql/#enabling-the-binlog).  
+2. Enable binary logging in the MySQL server. For detailed instructions, see [Debezium documentation - Enabling the binlog](https://debezium.io/docs/connectors/mysql/#enabling-the-binlog).  
 
     !!!note
         If you are using MySQL 8.0, use the following query to check the binlog status:

--- a/en/streaming-integrator/docs/quick-start-guide/getting-started/download-install-and-start-si.md
+++ b/en/streaming-integrator/docs/quick-start-guide/getting-started/download-install-and-start-si.md
@@ -25,7 +25,7 @@ In this scenario, the Streaming Integrator reads input data from a MySQL databas
 2. Enable binary logging in the MySQL server. For detailed instructions, see [Enabling the Binlog tutorial by debezium](https://debezium.io/docs/connectors/mysql/#enabling-the-binlog).  
 
     !!!note
-        If you are using MySQL 8.0, please use the following query to check the binlog status:
+        If you are using MySQL 8.0, use the following query to check the binlog status:
         ```
         SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
         FROM performance_schema.global_variables WHERE variable_name='log_bin';

--- a/en/streaming-integrator/docs/samples/CDCWithListeningMode.md
+++ b/en/streaming-integrator/docs/samples/CDCWithListeningMode.md
@@ -12,7 +12,7 @@ This sample demonstrates how to capture change data from MySQL using Siddhi. The
     3. Configure MySQL to [enable binary logging](https://debezium.io/docs/connectors/mysql/#enabling-the-binlog).<br/> 
 
         !!!note
-            If you are using MySQL 8.0, please use the following query to check the binlog status:
+            If you are using MySQL 8.0, use the following query to check the binlog status:
             ```
             SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
             FROM performance_schema.global_variables WHERE variable_name='log_bin';

--- a/en/streaming-integrator/docs/samples/CDCWithListeningMode.md
+++ b/en/streaming-integrator/docs/samples/CDCWithListeningMode.md
@@ -9,7 +9,15 @@ This sample demonstrates how to capture change data from MySQL using Siddhi. The
         1. Download the JDBC driver from the [MySQL website](https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.45.tar.gz).<br/>
         2. Unzip the archive.<br/>
         3. Copy the `mysql-connector-java-5.1.45-bin.jar` JAR and place it in the `<SI_TOOLING_HOME>/lib` directory.<br/>
-    3. Configure MySQL to [enable binary logging](https://debezium.io/docs/connectors/mysql/#enabling-the-binlog).<br/>
+    3. Configure MySQL to [enable binary logging](https://debezium.io/docs/connectors/mysql/#enabling-the-binlog).<br/> 
+
+        !!!note
+            If you are using MySQL 8.0, please use the following query to check the binlog status:
+            ```
+            SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
+            FROM performance_schema.global_variables WHERE variable_name='log_bin';
+            ```
+
     4. Enable state persistence in siddhi applications. To do this, open the `<SI_TOOLING_HOME>/conf/server/deployment.yaml` file and set the `state.persistence enabled=true` property.<br/>
     5. Create a database named `production` by issuing the following command.<br/>
         `create database production;`<br/>


### PR DESCRIPTION
## Purpose
> When working with CDC and MySQL, we have to enable binary logging as a pre-requisite. We ask to follow Debezium documentation [1] in order to do this. MySQL query for checking the status of binary logging is slightly different in MySQL 8.0, and this is not mentioned in Debezium documentation. 
This PR adds a note regarding this query, in places where the Debezium documentation is referred.

[1] https://debezium.io/documentation/reference/1.3/connectors/mysql.html