### PR TITLE
Correction on Message store and message processor for guaranteed delivery

### DIFF
--- a/en/micro-integrator/docs/use-cases/examples/rabbitmq_examples/store-forward-rabbitmq.md
+++ b/en/micro-integrator/docs/use-cases/examples/rabbitmq_examples/store-forward-rabbitmq.md
@@ -5,7 +5,7 @@ message broker and WSO2 Micro Integrator. Store and forward messaging is used fo
 
 This messaging pattern ensures guaranteed message delivery. That is, because request messages are stored in a message store, messages never get lost.
 
-As shown below, when a client sends a message, the <b>message processor</b> artifact in the Micro Integrator will route the messages to the RabbitMQ broker. The <b>message processor</b> artifact in the Micro Integrator will then process the message from the broker and send it to the back-end service.
+As shown below, when a client sends a message, the <b>message store</b> artifact in the Micro Integrator will route the messages to the RabbitMQ broker. The <b>message processor</b> artifact in the Micro Integrator will then process the message from the broker and send it to the back-end service.
 
 <img src="../../../../assets/img/rabbitmq/rabbitmq-store-and-forward.png"> 
 


### PR DESCRIPTION
Substituting "message processor" for "message store" as the image below indicates that it is the "message store" that forwards the message to the rabbitMQ. I believe this was a mistake.