### PR TITLE
[7.1.0] Adding setup docs for Gmail and Sheets to the navigation

### DIFF
--- a/en/micro-integrator/docs/references/connectors/gmail-connector/configuring-gmail-api.md
+++ b/en/micro-integrator/docs/references/connectors/gmail-connector/configuring-gmail-api.md
@@ -1,6 +1,6 @@
 # Setting up the Gmail API
 
-To use the Gmail API, you must have created a Gmail account. The Gmail API uses OAuth2 authentication with Tokens. You need to go through the following steps to obtain the necessary tokens unless you already have them.
+To use the Gmail API, you need to first create a Gmail account or have one already. The Gmail API uses OAuth2 authentication with Tokens. You need to go through the following steps to obtain the necessary tokens unless you already have them.
 
 ## Creating the Client ID and Client Secret
 

--- a/en/micro-integrator/docs/references/connectors/gmail-connector/configuring-gmail-api.md
+++ b/en/micro-integrator/docs/references/connectors/gmail-connector/configuring-gmail-api.md
@@ -1,3 +1,7 @@
+# Setting up the Gmail API
+
+To use the Gmail API, you must have created a Gmail account. The Gmail API uses OAuth2 authentication with Tokens. You need to go through the following steps to obtain the necessary tokens unless you already have them.
+
 ## Creating the Client ID and Client Secret
 
 1. Navigate to [API Credentials Page](https://console.developers.google.com/projectselector/apis/credentials) and sign in with your Google account.
@@ -39,7 +43,7 @@
 2. Select **Use your own OAuth credentials**, and provide the obtained Client ID and Client Secret values as above click on Close.
   <img src="../../../../assets/img/connectors/oath-configuration.png" title="Obtaining Oauth-configuration" width="800" alt="Obtaining Oauth-configuration" />
 
-3. Under Step 1, select `Gmail API v1` from the list of APIs, select all the scopes expect the [gmail.metadata scope](https://www.googleapis.com/auth/gmail.metadata scope).
+3. Under Step 1, select `Gmail API v1` from the list of APIs, select all the scopes except the [gmail.metadata scope](https://www.googleapis.com/auth/gmail.metadata scope).
 
   <img src="../../../../assets/img/connectors/select-scopes.png" title="Selecting Scopes" width="800" alt="Selecting Scopes" />
 

--- a/en/micro-integrator/docs/references/connectors/gmail-connector/gmail-connector-overview.md
+++ b/en/micro-integrator/docs/references/connectors/gmail-connector/gmail-connector-overview.md
@@ -16,7 +16,7 @@ For older versions, see the details in the connector store.
 
 ## Gmail Connector documentation
 
-* **[Creating the Client ID and Client Secret](configuring-gmail-api.md)**: You need to first create Gmail credentials for the connector to use in order to interact with Gmail.
+* **[Setting up the Gmail API](configuring-gmail-api.md)**: You need to first create Gmail credentials for the connector to use in order to interact with Gmail.
 
 * **[Gmail Connector Example](gmail-connector-example.md)**: This example demonstrates a scenario where a customer feedback Gmail account of a company can be easily managed using the WSO2 Gmail Connector. 
 

--- a/en/micro-integrator/docs/references/connectors/google-spreadsheet-connector/get-credentials-for-google-spreadsheet.md
+++ b/en/micro-integrator/docs/references/connectors/google-spreadsheet-connector/get-credentials-for-google-spreadsheet.md
@@ -1,4 +1,8 @@
-# Get Credentials for Google Spreadsheet
+# Setting up the Google Sheets API
+
+To use the Google Sheets API, you must have created a Gmail account. The Sheets API uses OAuth2 authentication with Tokens. You need to go through the following steps to obtain the necessary tokens unless you already have them.
+
+## Get Credentials for Google Sheets
 
 To obtain the Access Token, Client Id, Client Secret and Refresh Token, we need to follow the below steps. 
 

--- a/en/micro-integrator/docs/references/connectors/google-spreadsheet-connector/get-credentials-for-google-spreadsheet.md
+++ b/en/micro-integrator/docs/references/connectors/google-spreadsheet-connector/get-credentials-for-google-spreadsheet.md
@@ -1,6 +1,6 @@
 # Setting up the Google Sheets API
 
-To use the Google Sheets API, you must have created a Gmail account. The Sheets API uses OAuth2 authentication with Tokens. You need to go through the following steps to obtain the necessary tokens unless you already have them.
+To use the Google Sheets API, you need to first create a Gmail account or have one already. The Sheets API uses OAuth2 authentication with Tokens. You need to go through the following steps to obtain the necessary tokens unless you already have them.
 
 ## Get Credentials for Google Sheets
 
@@ -54,4 +54,3 @@ To obtain the Access Token, Client Id, Client Secret and Refresh Token, we need 
 
 5.  Under Step 2, click **Exchange authorization code for tokens** to generate and display the Access Token and Refresh Token. Now we are done with configuring the Google Sheets API.
   <img src="../../../../assets/img/connectors/refreshtoken.png" title="Getting Tokens" width="800" alt="Getting Tokens" />
-

--- a/en/micro-integrator/docs/references/connectors/google-spreadsheet-connector/google-spreadsheet-overview.md
+++ b/en/micro-integrator/docs/references/connectors/google-spreadsheet-connector/google-spreadsheet-overview.md
@@ -16,7 +16,7 @@ For older versions, see the details in the connector store.
 
 ## Google Spreadsheet Connector documentation
 
-* **[Get Credentials for Google Spreadsheet](get-credentials-for-google-spreadsheet.md)**: You need to obtain the Access Token, Client Id, Client Secret, and Refresh Token in order to integrate with Google Spreadsheet. 
+* **[Setting up the Google Sheets API](get-credentials-for-google-spreadsheet.md)**: You need to obtain the Access Token, Client Id, Client Secret, and Refresh Token in order to integrate with Google Spreadsheet. 
 
 * **[Google Spreadsheet Connector Example](google-spreadsheet-connector-example.md)**: This example explains how to use Google Spreadsheet Connector to create a Google spreadsheet, write data to it, and read it. 
 

--- a/en/micro-integrator/mkdocs.yml
+++ b/en/micro-integrator/mkdocs.yml
@@ -542,6 +542,7 @@ nav:
             - 'File Connector Reference': 'references/connectors/file-connector/3.x/file-connector-3.x-config.md'
         - Gmail Connector:
           - 'Gmail Overview': 'references/connectors/gmail-connector/gmail-connector-overview.md'
+          - 'Setting up the Gmail API': 'references/connectors/gmail-connector/configuring-gmail-api.md'
           - 'Gmail Example': 'references/connectors/gmail-connector/gmail-connector-example.md'
           - 'Gmail Reference': 'references/connectors/gmail-connector/gmail-connector-config.md'
         - Google Firebase Connector:
@@ -556,6 +557,7 @@ nav:
           - 'Google PubSub Reference': 'references/connectors/google-pubsub-connector/googlepubsub-connector-reference.md'
         - Google Spreadsheet Connector:
           - 'Google Spreadsheet Overview': 'references/connectors/google-spreadsheet-connector/google-spreadsheet-overview.md'
+          - 'Setting up the Sheets API': 'references/connectors/google-spreadsheet-connector/get-credentials-for-google-spreadsheet.md'
           - 'Google Spreadsheet Example': 'references/connectors/google-spreadsheet-connector/google-spreadsheet-connector-example.md'
           - 'Google Spreadsheet Reference': 'references/connectors/google-spreadsheet-connector/google-spreadsheet-connector-config.md'
         - ISO8583 Connector:


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

This PR will add the setup docs for Gmail and Sheets API to the side navigation. These docs are necessary for the relevant connector setup.

Related to https://github.com/wso2/docs-ei/issues/1865