### PR TITLE
Add instruction to use Log4j2 custom log appenders

### DIFF
--- a/en/micro-integrator/docs/administer-and-observe/logs/configuring_log4j_properties.md
+++ b/en/micro-integrator/docs/administer-and-observe/logs/configuring_log4j_properties.md
@@ -49,6 +49,9 @@ Filters log entries based on their level. For example, threshold set to 'WARN' w
 
 This section allows you to configure appenders individually. Log4j2 allows logging requests to print to multiple destinations. These output destinations are called 'Appenders'. You can attach several appenders to one logger.
 
+!!! Note
+    If the output destination is in another environment (such as a cloud storage), you need to [use custom log appenders](#using-custom-log-appenders).
+
 -   **CARBON_CONSOLE**: Logs to the console when the server is running.
 -   **CARBON_LOGFILE**: Writes the logs to MI_HOME/repository/logs/wso2carbon.log .
 -   **SERVICE_APPENDER**: Writes service invocations to `MI_HOME/repository/logswso2-MI-service.log`.
@@ -90,13 +93,13 @@ The logger element must have a name attribute specified. It may also have a **le
 
 ## Using Custom Log Appenders
 
-Custom log appenders for Log4j2 can be used to store application logs in various environments/systems, such as cloud storages.
+Custom log appenders for Log4j2 can be used to store application logs in various environments/systems such as cloud storages.
 
-But since WSO2 Micro Integrator works in an OSGi environment, such Log4j2 extensions cannot be used as they are. Therefore those extensions need to be modified to be compatible with WSO2 Micro Integrator. To modify an existing Log4j2 extension, follow the steps mentioned below.
+However, since WSO2 Micro Integrator works in an OSGi environment, such Log4j2 extensions cannot be used as they are. Therefore, you need to modify those extensions to be compatible with WSO2 Micro Integrator. Follow the steps given below to modify an existing Log4j2 extension:
 
-1. In the custom log appender, open the `pom.xml` file of the module which contains the `Log4j2Appender` class.
+1. In the custom log appender, open the `pom.xml` file of the module that contains the `Log4j2Appender` class.
 
-2. Under the `build` section, add the `maven-compiler-plugin` and the `maven-bundle-plugin` as follows.
+2. Under the `build` section, add `maven-compiler-plugin` and `maven-bundle-plugin` as follows.
 
     ```xml
     <plugins>
@@ -144,7 +147,7 @@ But since WSO2 Micro Integrator works in an OSGi environment, such Log4j2 extens
 
 3. Rebuild the related module and copy the built JAR file from the `target` directory to `<MI_HOME>/dropins` directory.
 
-4. Configure the custom appender as follows.
+4. Configure the custom appender in the `log4j2.properties` file as follows.
 
     ```properties
     appender.log4j2Custom.type = Log4j2Appender
@@ -152,5 +155,11 @@ But since WSO2 Micro Integrator works in an OSGi environment, such Log4j2 extens
     appender.log4j2Custom.layout.type = PatternLayout
     appender.log4j2Custom.layout.pattern = [%d] %5p {%c} - %m%ex%n
     ```
+    
+5. The custom appender should be added to the list of registered appenders in the `log4j2.properties` file as shown below.
 
-5. Restart the server.
+    ```properties
+    appenders = log4j2Custom, ....
+    ```
+
+6. Restart the server.


### PR DESCRIPTION
## Purpose
This PR adds instructions to use custom Log4j2 log appenders with WSO2 Micro Integrator.

Resolves https://github.com/wso2/docs-ei/issues/2260

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes