### PR TITLE
fixes EIINTERNAL-673

### DIFF
--- a/en/micro-integrator/docs/setup/performance_tuning/jms_transport_tuning.md
+++ b/en/micro-integrator/docs/setup/performance_tuning/jms_transport_tuning.md
@@ -40,6 +40,16 @@ To adjust the values of these properties, you can modify the server startup scri
     -   `snd_t_core=200`
     -   `snd_t_max=250`
 
+    !!! note "Determine a suitable value for lst_t_core and snd_t_core"
+        **`lst_t_core > Total number of consumers + 20`**
+
+        **`snd_t_core > Total number of consumers + 20`**
+
+        - `Total number of consumers = transport.jms.MaxConcurrentConsumers x Number of proxies`
+        - 20 is added as a buffer.
+        - Default value for `lst_t_core` and `snd_t_core` is 20.
+        - If you do not specify a value for `lst_t_core` and `snd_t_core`, the default values are applied.
+
 2.  Create a directory called `conf` under your `MI_HOME` directory and save the file in this directory.
 
 ## Tuning the JMS Listener


### PR DESCRIPTION
## Purpose
fixes EIINTERNAL-673 by adding a note as shown in the image below in [1].
[1] https://ei.docs.wso2.com/en/7.0.0/micro-integrator/setup/performance_tuning/jms_transport_tuning/#using-the-jmsproperties-file

<img width="1098" alt="Screenshot 2021-02-08 at 23 01 26" src="https://user-images.githubusercontent.com/5195851/107258261-9b037880-6a61-11eb-9f4a-7f8823b55cb5.png">
