### PR TITLE
removed EI 7.2.0 from versions page

### DIFF
--- a/en/docs/index.md
+++ b/en/docs/index.md
@@ -40,32 +40,6 @@ This is the current stable version of the project.
 
 ---
 
-### Pre-release versions
-
-These are the latest changes that are yet to be released.
-
-<table>
-    <tbody>
-        <tr>
-            <th>7.2.0</th>
-            <td>
-                <a id="pre-release-version-documentation-link">Documentation</a>
-            </td>
-            <td>
-                <a href="https://github.com/wso2/docs-ei" target="_blank">
-                    <div class="md-source-code-icon">
-                        <svg viewBox="0 0 24 24" width="24" height="24">
-                          <use xlink:href="#__github" width="24" height="24"></use>
-                        </svg>
-                    </div> Source Code
-                </a>
-            </td>
-        </tr>
-    </tbody>
-</table>
-
----
-
 ### Past Versions
 
 <table>


### PR DESCRIPTION
Since another EI release is not planned for the present, removing EI 7.2.0 from the versions page.