### PR TITLE
Update documentation with blocking mode fixes

### DIFF
--- a/en/micro-integrator/docs/references/mediators/call-Mediator.md
+++ b/en/micro-integrator/docs/references/mediators/call-Mediator.md
@@ -47,7 +47,7 @@ When using the Call mediator in the **blocking mode** (blocking=true), enable th
 ```
 
 !!! Note
-    The call mediator in the **blocking mode** (blocking=true), builds the message from the response payload. If no response message is expected by the client, you can set the OUT_ONLY property before the call mediator to avoid building the response payload.
+    The call mediator in the **blocking mode** (blocking=true), builds the message from the response payload. If no response message is expected by the client, you can set the **OUT_ONLY** property before the call mediator to avoid building the response payload. You may set the System property **allowEmptyBodyForHttp2xx** to **true**, if you want to receive response without body for HTTP status codes 200, 201 and 202 in the blocking mode.
     ``` xml
     <property name="OUT_ONLY" value="true"/>
     ```

--- a/en/micro-integrator/docs/references/mediators/call-Mediator.md
+++ b/en/micro-integrator/docs/references/mediators/call-Mediator.md
@@ -47,7 +47,7 @@ When using the Call mediator in the **blocking mode** (blocking=true), enable th
 ```
 
 !!! Note
-    The call mediator in the **blocking mode** (blocking=true), builds the message from the response payload. If no response message is expected by the client, you can set the **OUT_ONLY** property before the call mediator to avoid building the response payload. You may set the System property **allowEmptyBodyForHttp2xx** to **true**, if you want to receive response without body for HTTP status codes 200, 201 and 202 in the blocking mode.
+    The call mediator in **blocking mode** (blocking=true) builds the message from the response payload. If a response message is not expected by the client, you can set the **OUT_ONLY** property before the call mediator to avoid building the response payload. You may set the **allowEmptyBodyForHttp2xx** system property to **true** if you want to receive a response without the body for the following HTTP status codes in blocking mode: 200, 201, and 202.
     ``` xml
     <property name="OUT_ONLY" value="true"/>
     ```

--- a/en/micro-integrator/docs/references/mediators/property-reference/http-transport-properties.md
+++ b/en/micro-integrator/docs/references/mediators/property-reference/http-transport-properties.md
@@ -271,6 +271,47 @@ appending a context to the target URL in RESTful invocations.
 </tbody>
 </table>
 
+## NON_ERROR_HTTP_STATUS_CODES
+
+<table>
+	<tr>
+		<th>Parameter</th>
+		<th>Description</th>
+	</tr>
+<tbody>
+<tr class="odd">
+<td><p><strong>Name</strong></p></td>
+<td><p>non.error.http.status.codes</p></td>
+</tr>
+<tr class="even">
+<td><p><strong>Possible Values</strong></p></td>
+<td><p>HTTP status code number/comma separated numbers</p></td>
+</tr>
+<tr class="odd">
+<td><p><strong>Default Behavior</strong></p></td>
+<td><p>none</p></td>
+</tr>
+<tr class="even">
+<td><p><strong>Scope</strong></p></td>
+<td><p>axis2</p></td>
+</tr>
+<tr class="odd">
+<td><p><strong>Description</strong></p></td>
+<td><p>Set the HTTP status code(s) that should be considered as non-error HTTP status code(s) in blocking mode.</p></td>
+</tr>
+<tr class="even">
+<td><p><strong>Example</strong></p></td>
+<td><div class="content-wrapper">
+<div class="code panel pdl" style="border-width: 1px;">
+<div class="codeContent panelContent pdl">
+<div class="sourceCode" id="cb1" data-syntaxhighlighter-params="brush: java; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: java; gutter: false; theme: Confluence"><pre class="sourceCode java"><code class="sourceCode java"><span id="cb1-1"><a href="#cb1-1"></a>&lt;property name=<span class="st">&quot;non.error.http.status.codes&quot;</span> value=<span class="st">&quot;403&quot;</span> scope=<span class="st">&quot;axis2&quot; type=<span class="st">&quot;STRING&quot;</span>/&gt;</span></code></pre></div>
+</div>
+</div>
+</div></td>
+</tr>
+</tbody>
+</table>
+
 ## HTTP_SC_DESC
 
 <table>


### PR DESCRIPTION
## Purpose
This PR updates the documentation for the following fixes,
https://github.com/wso2/wso2-axis2/pull/201, https://github.com/wso2-support/wso2-axis2/pull/173

- The system property **allowEmptyBodyForHttp2xx** can be set to allow receiving response without body for HTTP status code 200, 201, 202 (for blocking calls)

- The property non.error.http.status.codes can be used to configure HTTP status codes that need to be considered as non-error status codes (for blocking calls)
`<property name="non.error.http.status.codes" scope="axis2" value="403" type="STRING"/>`