### PR TITLE
Add option to skip file permission check in the move operation

### DIFF
--- a/en/micro-integrator/docs/references/connectors/file-connector/file-connector-config.md
+++ b/en/micro-integrator/docs/references/connectors/file-connector/file-connector-config.md
@@ -701,6 +701,11 @@ The following operations allow you to work with the File Connector version 2. Cl
             <td>Set to true if you want to include the parent directory.</td>
             <td>Optional</td>
         </tr>
+        <tr>
+            <td>setAvoidPermission</td>
+            <td>Set to true if you want to skip the file permission check.</td>
+            <td>Optional</td>
+        </tr>
 	    <tr>
             <td>sourceSftpIdentities</td>
             <td>Location of the source's private key.</td>
@@ -736,6 +741,7 @@ The following operations allow you to work with the File Connector version 2. Cl
         <setStrictHostKeyChecking>{$ctx:setStrictHostKeyChecking}</setStrictHostKeyChecking>
         <filePattern>{$ctx:filePattern}</filePattern>
 	    <includeParentDirectory>{$ctx:includeParentDirectory}</includeParentDirectory>
+        <setAvoidPermission>{$ctx:setAvoidPermission}</setAvoidPermission>
 	    <sourceSftpIdentities>{$ctx:sftpIdentities}</sourceSftpIdentities>
         <sourceSftpIdentityPassphrase>{$ctx:sourceSftpIdentityPassphrase}</sourceSftpIdentityPassphrase>
         <targetSftpIdentities>{$ctx:targetSftpIdentities}</targetSftpIdentities>


### PR DESCRIPTION
## Purpose
Add the document changes related to the new property `setAvoidPermission` which is added to the file connector move operation by https://github.com/wso2-extensions/esb-connector-file/pull/164.