### PR TITLE
Update Amazon S3 connector docs with 2.0.1 release features

### DIFF
--- a/en/micro-integrator/docs/references/connectors/amazons3-connector/amazons3-connector-example.md
+++ b/en/micro-integrator/docs/references/connectors/amazons3-connector/amazons3-connector-example.md
@@ -265,9 +265,28 @@ Now let us read the information on `wso2engineers` that we stored in the Amazon 
     curl -H "Content-Type: application/xml" --request POST --data @data.xml http://127.0.0.1:8290/s3connector/info
     ```
 **Expected Response**:
-    You will receive a response like below containing the details of the engineer requested. 
-    ```
-    Julian Garfield, Software Engineer, Integration Group
+    You receive a response similar to the following. The `Content` element contains the contents of the file requested.
+
+    !!! note
+        The `Content` element is available only with Amazon S3 connector v2.0.1 and above.
+
+    ```xml
+    <getObjectResult>
+        <success>true</success>
+        <GetObjectResponse>
+            <AcceptRanges>bytes</AcceptRanges>
+            <Content>Julian Garfield, Software Engineer, Integration Group</Content>
+            <ContentLength>12</ContentLength>
+            <ContentType>text/plain; charset=utf-8</ContentType>
+            <DeleteMarker>false</DeleteMarker>
+            <ETag>"abc"</ETag>
+            <LastModified/>
+            <metadata/>
+            <MissingMeta>0</MissingMeta>
+            <PartsCount>0</PartsCount>
+            <TagCount>0</TagCount>
+        </GetObjectResponse>
+    </getObjectResult>
     ```
 
 In this example Amazon S3 connector is used to perform operations with Amazon S3 storage. You can receive details of the errors that occur when invoking S3 operations using the S3 responses itself. Please read the [Amazon S3 connector reference guide](amazons3-connector-reference.md) to learn more about the operations you can perform with the Amazon S3 connector.

--- a/en/micro-integrator/docs/references/connectors/amazons3-connector/amazons3-connector-reference.md
+++ b/en/micro-integrator/docs/references/connectors/amazons3-connector/amazons3-connector-reference.md
@@ -1798,6 +1798,13 @@ To use the Amazon S3 connector, add the <amazons3.init> element in your configur
             <td>Confirms that the requester knows that they will be charged for the request.</td>
             <td>Optional</td>
         </tr>
+        <tr>
+            <td>destinationFilePath</td>
+            <td>Specifies the path to the local file where the contents of the response needs to be written. If the destination file already exists or if the file is not writable by the current user, an exception will be thrown.
+            <br>
+            **Note**: This parameter is available only with Amazon S3 connector v2.0.1 and above.</td>
+            <td>Optional</td>
+        </tr>
     </table>
 
     **Sample configuration**


### PR DESCRIPTION
## Purpose
With https://github.com/wso2-extensions/esb-connector-amazons3/pull/50 the `getObject` operation of the Amazon S3 connector was improved. This doc adds the related new changes.

## User stories
- Add a new parameter called `destinationFilePath` to getObject operation to download the file to the local server.

![amazon_s3_reference](https://user-images.githubusercontent.com/18748929/131090248-878d2708-a4e1-4944-a9b7-34164c69d468.png)

- Set the file content in the GetObjectResponse.

![amazon_s3_example](https://user-images.githubusercontent.com/18748929/131090312-64f468c9-7c0c-4cd9-ad7b-0efaff52a933.png)
