### PR TITLE
Update kafka connector 2.2 instructions

### DIFF
--- a/en/micro-integrator/docs/references/connectors/kafka-connector/kafka-connector-producer-example.md
+++ b/en/micro-integrator/docs/references/connectors/kafka-connector/kafka-connector-producer-example.md
@@ -81,10 +81,11 @@ Navigate to the <KAFKA_HOME> and run the following command:
 bin/kafka-topics.sh --create --bootstrap-server localhost:9092 --replication-factor 1 --partitions 1 --topic test     
 ```
 
-> **Note**: If your Kafka version is older than 2.2, then `--bootstrap-server` does not supported and you need to use `--zookeeper` options as follows:
-> ```bash
-> bin/kafka-topics.sh --create --zookeeper localhost:2181 --replication-factor 1 --partitions 1 --topic test
-> ```
+!!! note 
+   If your Kafka version is older than 2.2, then the `--bootstrap-server` option will not be supported. Use the `--zookeeper` options as shown below.
+    ```bash
+    bin/kafka-topics.sh --create --zookeeper localhost:2181 --replication-factor 1 --partitions 1 --topic test
+    ```
 
 **Sample Request**:
    

--- a/en/micro-integrator/docs/references/connectors/kafka-connector/kafka-connector-producer-example.md
+++ b/en/micro-integrator/docs/references/connectors/kafka-connector/kafka-connector-producer-example.md
@@ -81,6 +81,11 @@ Navigate to the <KAFKA_HOME> and run the following command:
 bin/kafka-topics.sh --create --bootstrap-server localhost:9092 --replication-factor 1 --partitions 1 --topic test     
 ```
 
+> **Note**: If your Kafka version is older than 2.2, then `--bootstrap-server` does not supported and you need to use `--zookeeper` options as follows:
+> ```bash
+> bin/kafka-topics.sh --create --zookeeper localhost:2181 --replication-factor 1 --partitions 1 --topic test
+> ```
+
 **Sample Request**:
    
 Send a message to the Kafka broker using a CURL command or sample client.


### PR DESCRIPTION
Fix https://github.com/wso2/docs-apim/issues/3649

This instruction update should be only for the Kafka version lower than 2.2. The latest version does support the `--bootstrap-server` option. Therefore, a note was added along with the command to specify how to create a topic in Kafka 2.2 and lower versions.