### PR TITLE
Update json-examples.md

### DIFF
--- a/en/micro-integrator/docs/use-cases/examples/json_examples/json-examples.md
+++ b/en/micro-integrator/docs/use-cases/examples/json_examples/json-examples.md
@@ -172,17 +172,21 @@ For example, consider the following JSON message:
 The output converted to XML is as follows:
 
 ```xml
-<abc_jsonreader_32_def>this is a sample value</abc_jsonreader_32_def> 
+<abc_JsonReader_32_def>this is a sample value</abc_JsonReader_32_def> 
 ```
 
 !!! Tip
     The value 32 represents the standard char value of the space. This works other way around as well. When you need to convert XML to JSON, with a JSON element that needs to have a space within it. Then, you use " `         _JsonReader_32_        ` " in the XML element, to get the space in the JSON output. For example, if you consider the following XML payload;
 
-    `<abc_jsonreader_32_def>this is a sample value</abc_jsonreader_32_def>`
+```xml
+<abc_JsonReader_32_def>this is a sample value</abc_JsonReader_32_def>
+```
 
-    The JSON output will be as follows:
+The JSON output will be as follows:
 
-    `{ "abc def" : "this is a sample value"}`
+```json
+{ "abc def" : "this is a sample value"}
+```
 
 ## Handling XML to JSON conversion
 


### PR DESCRIPTION
Correct the Converting spaces part: \_JsonReader_32\_ needs capital letters

## Purpose
Converting XML files to JSON (and the other way around) and using spaces in JSON names does not work with the given `_jsonreader_32_` addition to XML tag names. 

## Goals
Use the correct `_JsonReader_32_` element.

## Approach
Modify the _JSON Examples_ documentation page to reflect the correct usage. 

## User stories
N/A

## Release note
Corrected space conversion between XML and JSON files.

## Documentation
https://ei.docs.wso2.com/en/latest/micro-integrator/use-cases/examples/json_examples/json-examples/#converting-spaces

## Training

## Certification
N/A, no foreseeable change to the certification.

## Marketing

## Automation tests

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

## Related PRs

## Migrations (if applicable)

## Test environment
 
## Learning